### PR TITLE
Makes sort ns comparator configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,16 @@ some snippet packages for Clojure:
  - David Nolen has created some [clojure-snippets](https://github.com/swannodette/clojure-snippets)
  - I've made some [datomic-snippets](https://github.com/magnars/datomic-snippets)
 
+## Changing the way how the ns declaration is sorted
+
+By default sort ns `sn` will sort your ns declaration alphabetically. You can change this by setting `cljr-sort-comparator` in your clj-refactor configuration and sort it longer first:
+
+```emacs-lisp
+(setq cljr-sort-comparator 'cljr--string-length-comparator)
+```
+
+This also means that you can write your own comparator function if you prefer. Comparator is called with two elements of the sub section of the ns declaration, and should return non-nil if the first element should sort before the second.
+
 ## Automatic insertion of namespace declaration
 
 When you open a blank `.clj`-file, clj-refactor inserts the namespace

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -109,6 +109,14 @@
   :group 'cljr
   :type 'boolean)
 
+(defcustom cljr-sort-comparator 'cljr--string-natural-comparator
+  "The comparator function to use to sort ns declaration. Set your
+   own if you see fit. Comparator is called with two elements of
+   the sub section of the ns declaration, and should return non-nil
+   if the first element should sort before the second."
+  :group 'cljr
+  :type 'function)
+
 (defcustom cljr-auto-sort-ns t
   "When true, sort ns form whenever adding to the form using clj-refactor
    functions."
@@ -380,6 +388,14 @@ errors."
 (defun cljr--only-alpha-chars (s)
   (replace-regexp-in-string "[^[:alnum:]]" "" s))
 
+(defun cljr--string-natural-comparator (s1 s2)
+  (string< (cljr--only-alpha-chars s1)
+           (cljr--only-alpha-chars s2)))
+
+(defun cljr--string-length-comparator (s1 s2)
+  (> (length s1)
+     (length s2)))
+
 ;;;###autoload
 (defun cljr-sort-ns ()
   (interactive)
@@ -388,9 +404,7 @@ errors."
       (ignore-errors
         (dolist (statement (->> (cljr--extract-ns-statements statement-type nil)
                              (-map 's-trim)
-                             (-sort (lambda (s1 s2)
-                                      (string< (cljr--only-alpha-chars s1)
-                                               (cljr--only-alpha-chars s2))))
+                             (-sort cljr-sort-comparator)
                              (-distinct)))
           (cljr--insert-in-ns statement-type)
           (insert statement))))))

--- a/features/sort-ns.feature
+++ b/features/sort-ns.feature
@@ -12,7 +12,7 @@ Feature: Sort ns form
     (ns ^{:doc "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
             eiusmod tempor incididunt ut labore (et dolore magna aliqua)."}
       furtive.runtime.session.bucket
-      (:use clojure.test 
+      (:use clojure.test
             clojure.test
             clojure.string)
       (:require [foo.bar :refer :all]
@@ -70,4 +70,38 @@ Feature: Sort ns form
 
       (defn foo [x]
         (:user-agent x))
+    """
+
+  Scenario: Sort ns with length comparator
+    When I insert:
+    """
+    (ns ^{:doc "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore (et dolore magna aliqua)."}
+      furtive.runtime.session.bucket
+      (:use clojure.test
+            clojure.test
+            clojure.string)
+      (:require [foo.bar :refer :all]
+                [clj-time.core :as clj-time])
+      (:import (java.security MessageDigest)
+               java.util.Calendar
+               [org.joda.time DateTime]
+               (java.nio.charset Charset)))
+    """
+    And I set sort comparator to string length
+    And I place the cursor before "Calendar"
+    And I press "C-! sn"
+    Then I should see:
+    """
+    (ns ^{:doc "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore (et dolore magna aliqua)."}
+      furtive.runtime.session.bucket
+      (:use clojure.string
+            clojure.test)
+      (:require [clj-time.core :as clj-time]
+                [foo.bar :refer :all])
+      (:import (java.security MessageDigest)
+               (java.nio.charset Charset)
+               [org.joda.time DateTime]
+               java.util.Calendar))
     """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -34,9 +34,17 @@
   (lambda ()
     (setq cljr-auto-sort-ns t)))
 
+(Given "^I set sort comparator to string length$"
+  (lambda ()
+     (setq cljr-sort-comparator 'cljr--string-length-comparator)))
+
+(Given "^I set sort comparator to string natural$"
+  (lambda ()
+     (setq cljr-sort-comparator 'cljr--string-natural-comparator)))
+
 (Given "^I exit multiple-cursors-mode"
-       (lambda ()
-         (multiple-cursors-mode 0)))
+  (lambda ()
+    (multiple-cursors-mode 0)))
 
 (Then "^the file should be named \"\\([^\"]+\\)\"$"
   (lambda (file-name-postfix)


### PR DESCRIPTION
- adds length comparator
## Known limitations
## Possible improvements
- want to add 'semantic' comparator eventually which puts requires, used ns-s from the same project on the top and the rest below. could also group required/used libs
