### PR TITLE
Fix case-insensitive stop-refering

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -746,10 +746,11 @@ Presently, there's no support for :use clauses containing :exclude."
   (save-excursion
     (cljr--goto-ns)
     (paredit-forward)
-    (while (re-search-forward (regexp-opt symbols 'symbols) nil t)
-      (paredit-backward)
-      (insert ns "/")
-      (paredit-forward))))
+	(let ((case-fold-search nil))
+	  (while (re-search-forward (regexp-opt symbols 'symbols) nil t)
+		(paredit-backward)
+		(insert ns "/")
+		(paredit-forward)))))
 
 ;;;###autoload
 (defun cljr-move-form ()

--- a/features/stop-refering.feature
+++ b/features/stop-refering.feature
@@ -13,6 +13,7 @@ Feature: Stop referring
       (:require [my.lib :refer [a b]]))
 
     (+ (a 1) (b 2))
+    (+ (A 1) (B 2))
     """
     And I place the cursor before "my.lib"
     And I press "C-! sr"
@@ -22,6 +23,7 @@ Feature: Stop referring
       (:require [my.lib]))
 
     (+ (my.lib/a 1) (my.lib/b 2))
+    (+ (A 1) (B 2))
     """
 
   Scenario: With :as
@@ -31,6 +33,7 @@ Feature: Stop referring
       (:require [my.lib :as lib :refer [a b]]))
 
     (+ (a 1) (b 2))
+    (+ (A 1) (B 2))
     """
     And I place the cursor before "my.lib"
     And I press "C-! sr"
@@ -40,4 +43,5 @@ Feature: Stop referring
       (:require [my.lib :as lib]))
 
     (+ (lib/a 1) (lib/b 2))
+    (+ (A 1) (B 2))
     """


### PR DESCRIPTION
stop-referring did a find-replace based off global preference for case
sensitivity. However, clojure vars are case sensitive, so it doesn't
make sense to respect global preference. 

What was happening to me was I
had an ns with `(:require [schema.core :as schema :refer [Str]))` which
was replacing both calls like `{schema/Any Str` to `{schema/Any
schema/Str}` as well as calls like `(str 25)` to `(schema/str 25)`
