### PR TITLE
Add cljr-sort-project-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This is it so far:
  - `ad`: add declaration for current top-level form
  - `dk`: destructure keys
  - `mf`: move one or more forms to another namespace, `:refer` any functions
+ - `sp`: Sort all dependency vectors in project.clj
 
 Combine with your keybinding prefix/modifier.
 
@@ -452,7 +453,7 @@ or set it to `:prompt` if you want to confirm before it inserts.
 
 ## Project clean up
 
-`cljr-project-clean` runs some clean up functions on all clj files in a project in bulk. By default these are `cljr-remove-unused-requires` and `cljr-sort-ns`. Before changes are made the function prompts if you really want to proceed as many files in the project can be potentially affected.
+`cljr-project-clean` runs some clean up functions on all clj files in a project in bulk. By default these are `cljr-remove-unused-requires` and `cljr-sort-ns`. Additionally, `cljr-sort-project-dependencies` is called to put the `project.clj` file in order.  Before any changes are made, the user is prompted for confirmation because this function can touch a large number of files.
 
 This promting can be switched off by setting `cljr-project-clean-prompt` nil:
 
@@ -483,6 +484,7 @@ You might also like
 - Comparator for sort require, use and import is configurable, add optional lenght based comparator to sort longer first [Benedek Fazekas](https://github.com/benedekfazekas)
 - Add semantic comparator to sort items closer to the current namespace first [Benedek Fazekas](https://github.com/benedekfazekas)
 - Add `cljr-project-clean` with configurable clean functions [Benedek Fazekas](https://github.com/benedekfazekas)
+- Add `cljr-sort-project-dependencies` [Lars Andersen](https://github.com/expez)
 
 #### From 0.11 to 0.12
 
@@ -543,7 +545,7 @@ Run the tests with:
 ## Contributors
 
 - [AlexBaranosky](https://github.com/AlexBaranosky) added a bunch of features. See the [Changelog](#changelog) for details.
-- [Lars Andersen](https://github.com/expez) added `cljr-replace-use`, `cljr-add-declaration` and `cljr-move-form`.
+- [Lars Andersen](https://github.com/expez) added `cljr-replace-use`, `cljr-add-declaration` and `cljr-move-form`, `cljr-sort-project-dependencies`.
 - [Benedek Fazekas](https://github.com/benedekfazekas) added `cljr-remove-unused-requires` and improved on the let-expanding functions.
 
 Thanks!

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -143,7 +143,8 @@
   :group 'cljr
   :type 'boolean)
 
-(defcustom cljr-project-clean-functions (list 'cljr-remove-unused-requires 'cljr-sort-ns)
+(defcustom cljr-project-clean-functions
+  (list 'cljr-remove-unused-requires 'cljr-sort-ns)
   "List of functions to run on all the clj files in the project
    when you perform project clean."
   :group 'cljr
@@ -180,30 +181,31 @@
   (read-kbd-macro (concat prefix " " keys)))
 
 (defun cljr--add-keybindings (key-fn)
-  (define-key clj-refactor-map (funcall key-fn "rf") 'cljr-rename-file)
-  (define-key clj-refactor-map (funcall key-fn "ru") 'cljr-replace-use)
-  (define-key clj-refactor-map (funcall key-fn "au") 'cljr-add-use-to-ns)
-  (define-key clj-refactor-map (funcall key-fn "ar") 'cljr-add-require-to-ns)
-  (define-key clj-refactor-map (funcall key-fn "ai") 'cljr-add-import-to-ns)
-  (define-key clj-refactor-map (funcall key-fn "sn") 'cljr-sort-ns)
-  (define-key clj-refactor-map (funcall key-fn "rr") 'cljr-remove-unused-requires)
-  (define-key clj-refactor-map (funcall key-fn "sr") 'cljr-stop-referring)
-  (define-key clj-refactor-map (funcall key-fn "th") 'cljr-thread)
-  (define-key clj-refactor-map (funcall key-fn "uw") 'cljr-unwind)
-  (define-key clj-refactor-map (funcall key-fn "ua") 'cljr-unwind-all)
-  (define-key clj-refactor-map (funcall key-fn "il") 'cljr-introduce-let)
-  (define-key clj-refactor-map (funcall key-fn "el") 'cljr-expand-let)
-  (define-key clj-refactor-map (funcall key-fn "ml") 'cljr-move-to-let)
-  (define-key clj-refactor-map (funcall key-fn "mf") 'cljr-move-form)
-  (define-key clj-refactor-map (funcall key-fn "tf") 'cljr-thread-first-all)
-  (define-key clj-refactor-map (funcall key-fn "tl") 'cljr-thread-last-all)
-  (define-key clj-refactor-map (funcall key-fn "cp") 'cljr-cycle-privacy)
-  (define-key clj-refactor-map (funcall key-fn "cc") 'cljr-cycle-coll)
-  (define-key clj-refactor-map (funcall key-fn "cs") 'cljr-cycle-stringlike)
-  (define-key clj-refactor-map (funcall key-fn "ci") 'cljr-cycle-if)
   (define-key clj-refactor-map (funcall key-fn "ad") 'cljr-add-declaration)
+  (define-key clj-refactor-map (funcall key-fn "ai") 'cljr-add-import-to-ns)
+  (define-key clj-refactor-map (funcall key-fn "ar") 'cljr-add-require-to-ns)
+  (define-key clj-refactor-map (funcall key-fn "au") 'cljr-add-use-to-ns)
+  (define-key clj-refactor-map (funcall key-fn "cc") 'cljr-cycle-coll)
+  (define-key clj-refactor-map (funcall key-fn "ci") 'cljr-cycle-if)
+  (define-key clj-refactor-map (funcall key-fn "cp") 'cljr-cycle-privacy)
+  (define-key clj-refactor-map (funcall key-fn "cs") 'cljr-cycle-stringlike)
   (define-key clj-refactor-map (funcall key-fn "dk") 'cljr-destructure-keys)
-  (define-key clj-refactor-map (funcall key-fn "pc") 'cljr-project-clean))
+  (define-key clj-refactor-map (funcall key-fn "el") 'cljr-expand-let)
+  (define-key clj-refactor-map (funcall key-fn "il") 'cljr-introduce-let)
+  (define-key clj-refactor-map (funcall key-fn "mf") 'cljr-move-form)
+  (define-key clj-refactor-map (funcall key-fn "ml") 'cljr-move-to-let)
+  (define-key clj-refactor-map (funcall key-fn "pc") 'cljr-project-clean)
+  (define-key clj-refactor-map (funcall key-fn "rf") 'cljr-rename-file)
+  (define-key clj-refactor-map (funcall key-fn "rr") 'cljr-remove-unused-requires)
+  (define-key clj-refactor-map (funcall key-fn "ru") 'cljr-replace-use)
+  (define-key clj-refactor-map (funcall key-fn "sn") 'cljr-sort-ns)
+  (define-key clj-refactor-map (funcall key-fn "sp") 'cljr-sort-project-dependencies)
+  (define-key clj-refactor-map (funcall key-fn "sr") 'cljr-stop-referring)
+  (define-key clj-refactor-map (funcall key-fn "tf") 'cljr-thread-first-all)
+  (define-key clj-refactor-map (funcall key-fn "th") 'cljr-thread)
+  (define-key clj-refactor-map (funcall key-fn "tl") 'cljr-thread-last-all)
+  (define-key clj-refactor-map (funcall key-fn "ua") 'cljr-unwind-all)
+  (define-key clj-refactor-map (funcall key-fn "uw") 'cljr-unwind))
 
 ;;;###autoload
 (defun cljr-add-keybindings-with-prefix (prefix)
@@ -1423,7 +1425,10 @@ front of function literals and sets."
 
 ;; ------ project clean --------
 
+;;;###autoload
 (defun cljr-project-clean ()
+  "Runs `cljr-project-clean-functions' on every clojure file, then
+sorts the project's dependency vectors."
   (interactive)
   (when (or (not cljr-project-clean-prompt)
             (yes-or-no-p "Cleaning your project might change many of your clj files. Do you want to proceed?"))
@@ -1438,7 +1443,30 @@ front of function literals and sets."
           (ignore-errors (-map 'funcall cljr-project-clean-functions))
           (save-buffer)
           (when find-file-p
-            (kill-buffer)))))))
+            (kill-buffer)))))
+    (cljr-sort-project-dependencies)))
+
+;;;###autoload
+(defun cljr-sort-project-dependencies ()
+  (interactive)
+  "Sorts all dependency vectors in project.clj"
+  (save-window-excursion
+    (find-file (cljr--project-file))
+    (goto-char (point-min))
+    (while (re-search-forward ":dependencies" (point-max) t)
+      (forward-char)
+      (when (looking-at "\\[")
+        (->> (cljr--delete-and-extract-sexp)
+          (s-chop-prefix "[")
+          (s-chop-suffix "]")
+          s-lines
+          (-map #'s-trim)
+          (-sort #'string<)
+          (s-join "\n")
+          (insert "["))
+        (insert "]")))
+    (indent-region (point-min) (point-max))
+    (save-buffer)))
 
 ;; ------ minor mode -----------
 

--- a/features/sort-project-dependencies.feature
+++ b/features/sort-project-dependencies.feature
@@ -1,0 +1,53 @@
+Feature: Sort project dependencies
+
+  Background:
+    Given I have a project "cljr" in "tmp"
+    And I open file "tmp/project.clj"
+    And I clear the buffer
+
+  Scenario: All dependency vectors are sorted
+    When I insert:
+    """
+    (defproject refactor-nrepl "0.1.0-SNAPSHOT"
+      :description "nREPL middleware to support editor agnostic refactoring"
+      :url "http://github.com/clojure-emacs/refactor-nrepl"
+      :dependencies [[org.clojure/clojure "1.5.1"]
+                     [org.clojure/tools.nrepl "0.2.3"]
+                     [org.clojure/tools.analyzer "0.5.0"]
+                     [org.clojure/tools.analyzer.jvm "0.5.0"]
+                     [org.clojure/tools.namespace "0.2.5"]
+                     [org.clojure/tools.reader "0.8.5"]
+                     [clj-http "0.9.2"]]
+      :profiles {:test {:dependencies [[print-foo "0.5.3"]]}
+                 :1.5 {:dependencies [[org.clojure/tools.analyzer.jvm "0.5.0"]
+                                      [org.clojure/clojure "1.5.1"]
+                                      [org.clojure/tools.namespace "0.2.5"]
+                                      [org.clojure/tools.analyzer "0.5.0"]]}
+                 :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+                 :1.7 {:dependencies [[org.clojure/clojure "1.7.0-master-SNAPSHOT"]]}
+                 :dev {:plugins [[jonase/eastwood "0.1.4"]]
+                       :repositories [["snapshots" "http://oss.sonatype.org/content/repositories/snapshots"]]}})
+    """
+    And I press "C-! sp"
+    Then I should see:
+    """
+    (defproject refactor-nrepl "0.1.0-SNAPSHOT"
+      :description "nREPL middleware to support editor agnostic refactoring"
+      :url "http://github.com/clojure-emacs/refactor-nrepl"
+      :dependencies [[clj-http "0.9.2"]
+                     [org.clojure/clojure "1.5.1"]
+                     [org.clojure/tools.analyzer "0.5.0"]
+                     [org.clojure/tools.analyzer.jvm "0.5.0"]
+                     [org.clojure/tools.namespace "0.2.5"]
+                     [org.clojure/tools.nrepl "0.2.3"]
+                     [org.clojure/tools.reader "0.8.5"]]
+      :profiles {:test {:dependencies [[print-foo "0.5.3"]]}
+                 :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]
+                                      [org.clojure/tools.analyzer "0.5.0"]
+                                      [org.clojure/tools.analyzer.jvm "0.5.0"]
+                                      [org.clojure/tools.namespace "0.2.5"]]}
+                 :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+                 :1.7 {:dependencies [[org.clojure/clojure "1.7.0-master-SNAPSHOT"]]}
+                 :dev {:plugins [[jonase/eastwood "0.1.4"]]
+                       :repositories [["snapshots" "http://oss.sonatype.org/content/repositories/snapshots"]]}})
+    """


### PR DESCRIPTION
Calling this fn will sort all the dependency vectors in project.clj.

When cljr-add-project-dependency gets merged in it makes sense to extend
this with a cljr-auto-sort-project-dependencies variable, to keep the
vectors sorted.

If the dependency vector contains any comments, these will bubble to the
top.  It would be possible to associate one, or more comments, with the
following dependency, but--shiiiiiiiiiiit.  Just use end-of-line
comments in project.clj!
