### PR TITLE
Add `cljr-cycle-thread` for toggling between thread first/last

### DIFF
--- a/features/cycling.feature
+++ b/features/cycling.feature
@@ -206,3 +206,35 @@ Scenario: Cycling if-not to if, in outer if-not
        (then AAA)
        (else BBB)))
    """
+
+Scenario: Cycling thread-first to thread-last
+   When I insert:
+   """
+   (defn foo [coll]
+     (-> coll
+         (map inc)))
+   """
+   And I place the cursor after "(map"
+   And I press "C-! ct"
+   Then I should see:
+   """
+   (defn foo [coll]
+     (->> coll
+          (map inc)))
+   """
+
+Scenario: Cycling thread-last to thread-first
+   When I insert:
+   """
+   (defn foo []
+     (-> {}
+         (->> (assoc :bar 1))))
+   """
+   And I place the cursor after "(assoc"
+   And I press "C-! ct"
+   Then I should see:
+   """
+   (defn foo []
+     (-> {}
+         (-> (assoc :bar 1))))
+   """


### PR DESCRIPTION
Allows toggling between `->` and `->>` inside the thread body. I relaxed the regex so that `some->`, `cond->`, as well as user-defined threading style macros, are also supported.

This is my first ever attempt at writing some emacs lisp! please let me know if there's room for any improvement :)

Luke
