### PR TITLE
Fix add-missing-libspec with records and deftypes

### DIFF
--- a/features/add-missing-libspec.feature
+++ b/features/add-missing-libspec.feature
@@ -34,3 +34,12 @@ Feature: resolve-missing; nrepl middleware response mocked
     (ns example.core
       (:require [clojure.string :as str]))
     """
+
+  Scenario: Require defrecord
+    Given I call the add-missing-libspec callback directly with mock data to require WebrequestHandler
+    Then I should see:
+    """
+    (ns example.core
+      (:require modular.ring)
+      (:import modular.ring.WebrequestHandler)
+    """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -66,20 +66,24 @@
     (run-rename-symbol "example.two" '(6  7  1  10  "star*"  "tmp/src/example/two.clj"  "" 8  8  17  27  "star*"  "tmp/src/example/one.clj"  "") "asterisk*")))
 
 (Given "^I call the add-missing-libspec callback directly with mock data to import"
-  (lambda ()
-    (cljr--add-missing-libspec "Date" "java.util.Date" "import")))
+       (lambda ()
+         (cljr--add-missing-libspec "Date" '((java.util.Date :class)))))
 
 (Given "^I call the add-missing-libspec callback directly with mock data to refer split"
-  (lambda ()
-    (cljr--add-missing-libspec "split" "clojure.string" "require")))
+       (lambda ()
+         (cljr--add-missing-libspec "split" '((clojure.string  :ns)))))
 
 (Given "^I call the add-missing-libspec callback directly with mock data to alias clojure.string"
-  (lambda ()
-    (cljr--add-missing-libspec "str/split" "clojure.string" "require")))
+       (lambda ()
+         (cljr--add-missing-libspec "str/split" '((clojure.string :ns)))))
+
+(Given "^I call the add-missing-libspec callback directly with mock data to require WebrequestHandler"
+       (lambda ()
+         (cljr--add-missing-libspec "WebrequestHandler" '((modular.ring.WebrequestHandler :type)))))
 
 (Then "^the file should be named \"\\([^\"]+\\)\"$"
-  (lambda (file-name-postfix)
-    (assert (s-ends-with? file-name-postfix (buffer-file-name)) nil "Expected %S to end with %S" (buffer-file-name) file-name-postfix)))
+      (lambda (file-name-postfix)
+        (assert (s-ends-with? file-name-postfix (buffer-file-name)) nil "Expected %S to end with %S" (buffer-file-name) file-name-postfix)))
 
 (And "^the cursor is inside the first defn form$"
   (lambda ()


### PR DESCRIPTION
This also fixes an assumption that anything with capitalized names were
classes, which bit me when using prismatic/schema.

The middleware had to be changed to return more information.  We have to
know whether what we're importing is a missing ns, a missing
deftype/defrecord or a missing class.  It now returns an alist of the
following form ((candidate1 . type1)  (candidate2 . type2)..) where
:type is :record, :type, :class or :ns.  When we're importing interfaces
a class is generated and the import mechanism the same so no effort is
made to distinguish between tehse cases.

The case of missing types and records is most complex because we have to
both require the ns, in order to trigger compilation, and then import
the resulting class.