### PR TITLE
Add cljr-reify-to-defrecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-- add `cljr-show-changelog` so users don't have to visit github to find out what's changed after a package update.
-
 ## master (unreleased)
+
+- Add `cljr-reify-to-defrecord`
+- Add `cljr-show-changelog` so users don't have to visit github to find out what's changed after a package update.
 
 ## 1.0.5
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ This is it so far:
  - `ua`: fully unwind a threaded expression
  - `uw`: unwind a threaded expression
 
+The following functions are available, and supported, but used rarely enough that they're not given a keybinding:
+
+* `cljr-reify-to-record` change a call to reify with a call to a defrecord constructor.
+
 [Using refactor-nrepl](#refactor-nrepl-middleware), you also get:
 
  - `am`: add a missing libspec

--- a/features/reify-to-defrecord.feature
+++ b/features/reify-to-defrecord.feature
@@ -1,0 +1,101 @@
+Feature: Turn a reify call into a call to the constructor of a newly created defrecord
+
+  Background:
+    Given I have a project "cljr" in "tmp"
+    And I have a clojure-file "tmp/src/cljr/core.clj"
+    And I open file "tmp/src/cljr/core.clj"
+    And I clear the buffer
+
+  Scenario: Replace a call to reify with a call to defrecord constructor
+    When I insert:
+    """
+    (defn create-runner []
+      (reify Runnable
+        (run [this] :running)))
+    """
+    And I place the cursor before "this"
+    And I start an action chain
+    And I press "M-x"
+    And I type "cljr-reify-to-defrecord"
+    And I press "RET"
+    And I type "Runner"
+    And I execute the action chain
+    Then I should see:
+    """
+    (defrecord Runner []
+      Runnable
+      (run [this] :running))
+
+    (defn create-runner []
+      (Runner.))
+    """
+
+  Background:
+    Given I have a project "cljr" in "tmp"
+    And I have a clojure-file "tmp/src/cljr/core.clj"
+    And I open file "tmp/src/cljr/core.clj"
+    And I clear the buffer
+
+  Scenario: Replace a call to reify with a call to defrecord constructor in nested context
+    When I insert:
+    """
+    (.listFiles (java.io.File. ".")
+                (reify
+                  java.io.FileFilter
+                  (accept [this f]
+                    (.isDirectory f))))
+    """
+    And I place the cursor before "this"
+    And I start an action chain
+    And I press "M-x"
+    And I type "cljr-reify-to-defrecord"
+    And I press "RET"
+    And I type "FileFilteringFoo"
+    And I execute the action chain
+    Then I should see:
+    """
+    (defrecord FileFilteringFoo []
+      java.io.FileFilter
+      (accept [this f]
+        (.isDirectory f)))
+
+    (.listFiles (java.io.File. ".")
+                (FileFilteringFoo.))
+    """
+
+  Background:
+    Given I have a project "cljr" in "tmp"
+    And I have a clojure-file "tmp/src/cljr/core.clj"
+    And I open file "tmp/src/cljr/core.clj"
+    And I clear the buffer
+
+  Scenario: Replace a call to reify with a call to defrecord constructor with multiple interfaces
+    When I insert:
+    """
+    (.listFiles (java.io.File. ".")
+                (reify
+                  java.io.FileFilter
+                  (accept [this f]
+                    (.isDirectory f))
+                  java.lang.Object
+                  (toString [this] (println "'sup?"))))))
+    """
+    And I place the cursor before "this"
+    And I start an action chain
+    And I press "M-x"
+    And I type "cljr-reify-to-defrecord"
+    And I press "RET"
+    And I type "FileFilteringFoo"
+    And I execute the action chain
+    Then I should see:
+    """
+    (defrecord FileFilteringFoo []
+      java.io.FileFilter
+      (accept [this f]
+        (.isDirectory f))
+      java.lang.Object
+      (toString [this] (println "'sup?")))
+
+    (.listFiles (java.io.File. ".")
+                (FileFilteringFoo.))
+    """


### PR DESCRIPTION
This function is currently unbound because `rr` is bound to
`remove-unused-requires`.  I expect this function to be used rarely
enough that calling it through `M-x` is going to be acceptable.

This is the first half of #127.

Is it what you had in mind @mtnygard?

