### PR TITLE
[Fix #145] add cljr-show-changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- add `cljr-show-changelog` so users don't have to visit github to find out what's changed after a package update.
+
 ## master (unreleased)
 
 ## 1.0.5

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This is it so far:
  - `rl`: remove-let, inline all variables and remove the let form
  - `rr`: remove unused requires
  - `ru`: replace all `:use` in namespace with `:refer :all`
+ - `sc`: show the project's changelog to learn about recent changes
  - `sn`: sort :use, :require and :import in the ns form
  - `sp`: Sort all dependency vectors in project.clj
  - `sr`: stop referring (removes `:refer []` from current require, fixing references)

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -232,6 +232,7 @@ with the middleware."
     ("rs" . (cljr-rename-symbol "Rename symbol"))
     ("ru" . (cljr-replace-use "Replace use"))
     ("sn" . (cljr-sort-ns "Sort ns"))
+    ("sc" . (cljr-show-changelog "Show the project's changelog"))
     ("sp" . (cljr-sort-project-dependencies "Sort project dependencies"))
     ("sr" . (cljr-stop-referring "Stop referring"))
     ("tf" . (cljr-thread-first-all "Thread first all"))
@@ -360,6 +361,16 @@ list of (fn args) to pass to `apply''"
             (args (if (listp fn-and-args) (cdr fn-and-args) nil)))
         (apply f args)))
     (point)))
+
+(defun cljr-show-changelog ()
+  "Show the changelog for `clj-refactor'."
+  (interactive)
+  (let* ((cljr (second (assoc 'clj-refactor package-alist)))
+         (dir (package-desc-dir cljr)))
+    (find-file (format "%s/CHANGELOG.md" dir))
+    (when (fboundp 'markdown-mode)
+      (markdown-mode))
+    (view-mode 1)))
 
 ;; ------ file -----------
 


### PR DESCRIPTION
Check the project's changelog, in emacs, after updating clj-refactor to
learn about any user-visible changes.