### PR TITLE
Teach cljr--add-test-use-declarations how to find source ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `cljr-reify-to-defrecord`
 - Add `cljr-show-changelog` so users don't have to visit github to find out what's changed after a package update.
 - Add `cljr-create-fn-from-example` to create function stub based on example usage
+- Now cljr--add-test-use-declarations actually checks the file system in order to find its require for the source ns.
 
 ## 1.0.5
 

--- a/features/auto-ns.feature
+++ b/features/auto-ns.feature
@@ -2,6 +2,7 @@ Feature: Add namespace to blank .clj files
 
   Background:
     Given I have a project "cljr" in "tmp"
+    When I have a clojure-file "tmp/src/cljr/core.clj"
 
   Scenario: Source file
     When I open file "tmp/src/cljr/core.clj"
@@ -12,6 +13,24 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.core-test
+      (:require [cljr.core :refer :all]
+                [clojure.test :refer :all]))
+    """
+
+  Scenario: Test file with foo_ prefix
+    When I open file "tmp/test/cljr/foo_core.clj"
+    Then I should see:
+    """
+    (ns cljr.foo-core
+      (:require [cljr.core :refer :all]
+                [clojure.test :refer :all]))
+    """
+
+ Scenario: Test file with _bar suffix
+    When I open file "tmp/test/cljr/core_bar.clj"
+    Then I should see:
+    """
+    (ns cljr.core-bar
       (:require [cljr.core :refer :all]
                 [clojure.test :refer :all]))
     """
@@ -27,6 +46,21 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.core-test
+      (:require [cljr.core :refer :all]
+                [midje.sweet :refer :all]))
+    """
+
+  Scenario: Midje with t_ prefix
+    When I open file "tmp/project.clj"
+    And I press "C-M-f"
+    And I press "C-b"
+    And I press "C-j"
+    And I type ":profiles {:dev {:dependencies [[midje "1.4"]]}}"
+    And I press "C-x C-s"
+    When I open file "tmp/test/cljr/t_core.clj"
+    Then I should see:
+    """
+    (ns cljr.t-core
       (:require [cljr.core :refer :all]
                 [midje.sweet :refer :all]))
     """

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -33,8 +33,8 @@
  (add-hook 'clojure-mode-hook (lambda () (clj-refactor-mode))))
 
 (Before
- ;; Before each scenario is run
- )
+ (save-all-buffers-dont-ask)
+ (kill-matching-buffers-dont-ask "clj"))
 
 (defun save-all-buffers-dont-ask ()
   (dolist (buffer (buffer-list))


### PR DESCRIPTION
This improvement/fix is basically what we discuss [in here](https://github.com/bbatsov/projectile/issues/642#issuecomment-107986794). It allows filling up the newly created test buffer with the right source namespace.

The source namespace is not obtained by chopping ```_test``` only, but it is actually looked up in the ```src``` folder.

This is the biggest ```elisp``` piece of code I have ever written (my first baby) and it might containe mistakes which I will fix asap of course in case :smile: 

Together with this addition, [mechanical test generation](https://github.com/bbatsov/projectile/issues/642#issuecomment-107596828) can finally come to life.

@expez bbatsov/projectile#642
