### PR TITLE
[Fix #138] Add cljr-describe-refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- Add `cljr-describe-refactoring` which shows the wiki page describing one of the available refactorings inline in emacs.
 - Add `cljr-rename-file-or-dir` to replace `cljr-rename-file`.
 - Add `cljr-inline-symbol` which replaces the symbol at point with its definition.
 - add `cljr-add-stubs` which adds a skeleton implementation of the protocol or interface at point.


### PR DESCRIPTION
This new op slurps the wiki page describing one of our refactorings and
displays it inline in emacs, gif and all.

Right now there appears to be some sort of bug related to the gif
playback, some are playing incredibly fast while others incredibly slow.