### PR TITLE
Introduce let form when attempting to move-to-let without one

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1454,9 +1454,11 @@ Return nil if there are no more levels to unwind."
 (add-to-list 'mc--default-cmds-to-run-once 'cljr-introduce-let)
 
 (defun cljr--goto-let ()
-  (while (not (or (cljr--toplevel-p)
-                  (looking-at "\(\\(when-let\\|if-let\\|let\\)\\( \\|\\[\\)")))
-    (paredit-backward-up)))
+  (let ((target-expr "\(\\(when-let\\|if-let\\|let\\)\\( \\|\\[\\)"))
+    (while (not (or (cljr--toplevel-p)
+                    (looking-at target-expr)))
+      (paredit-backward-up))
+    (looking-at target-expr)))
 
 (defun cljr--get-let-bindings ()
   "Returns a list of lists. The inner lists contain two elements first is
@@ -1514,16 +1516,19 @@ Return nil if there are no more levels to unwind."
 ;;;###autoload
 (defun cljr-move-to-let ()
   (interactive)
-  (save-excursion
-    (let ((contents (cljr--delete-and-extract-sexp)))
-      (cljr--prepare-to-insert-new-let-binding)
-      (insert contents))
-    (backward-sexp)
-    (insert " ")
-    (backward-char)
-    (mc/create-fake-cursor-at-point))
-  (add-hook 'multiple-cursors-mode-disabled-hook 'cljr--replace-sexp-with-binding-in-let)
-  (mc/maybe-multiple-cursors-mode))
+  (if (not (save-excursion (cljr--goto-let)))
+      (cljr-introduce-let)
+    (progn
+      (save-excursion
+        (let ((contents (cljr--delete-and-extract-sexp)))
+          (cljr--prepare-to-insert-new-let-binding)
+          (insert contents))
+        (backward-sexp)
+        (insert " ")
+        (backward-char)
+        (mc/create-fake-cursor-at-point))
+      (add-hook 'multiple-cursors-mode-disabled-hook 'cljr--replace-sexp-with-binding-in-let)
+      (mc/maybe-multiple-cursors-mode))))
 
 (defun cljr--prepare-to-insert-new-let-binding ()
   (if (cljr--inside-let-binding-form-p)

--- a/features/let-binding.feature
+++ b/features/let-binding.feature
@@ -157,6 +157,24 @@ Feature: Let bindings
          :body body}))
     """
 
+  Scenario: Introduce let if let does not exist
+    When I insert:
+    """
+    (defn handle-request
+      {:status (or status 500)
+       :body body})
+    """
+    And I place the cursor before "(or status 500)"
+    And I press "C-! ml"
+    And I type "status"
+    Then I should see:
+    """
+    (defn handle-request
+      {:status (let [status (or status 500)]
+                 status)
+       :body body})
+    """
+
   Scenario: Move to let, multiple occurance
     When I insert:
     """


### PR DESCRIPTION
I noticed when using `move-to-let` that, if I wasn't already inside a `let` form, it would attach itself to the top level form - my function declaration - and into the function bindings. This change will instead introduce a new `let` form if it gets to the top level expression without finding one.

Thanks for all the excellent work!