### PR TITLE
fix issue with LIMIT of looking-back

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -380,7 +380,7 @@ if SAVE-EXCURSION is T POINT does not move."
 
 (defun cljr--goto-toplevel ()
   (paredit-backward-up (cljr--depth-at-point))
-  (when (looking-back "#")
+  (when (looking-back "#\\=")
     (backward-char)))
 
 (defun cljr--toplevel-p ()
@@ -516,7 +516,7 @@ at the opening parentheses of an anonymous function."
             (let ((fn-end (save-excursion (paredit-forward) (point))))
               (when (and (< fn-beg pt-orig) (< pt-orig fn-end))
                 (setq found-fn-p t)
-                (when (looking-back "#")
+                (when (looking-back "#\\=")
                   (backward-char))))
           (when (<= (point) search-bound)
             (error "Can't find definition of anonymous function!")))))))
@@ -1024,7 +1024,7 @@ returns (used.ns.lib1 used.ns.lib2)"
   (let ((use-end (save-excursion (forward-sexp) (point))))
     (prog1
         (re-search-forward "\\(\\(\\( \\)\\{2,\\}\\|:use \\)\\(\\[\\(.\\|\n\\)*?\\]\\)\\)\\|\\((:use [^]]+?)\\)" use-end t nth)
-      (if (and (looking-back "\\]") (looking-at "\\]"))
+      (if (and (looking-back "\\]\\=") (looking-at "\\]"))
           (paredit-backward-up)
         (paredit-backward)))))
 
@@ -1421,7 +1421,7 @@ Return nil if there are no more levels to unwind."
          (beg (progn (paredit-backward)
                      (point)))
          (contents (buffer-substring beg end)))
-    (if (looking-back "(" 1)
+    (if (looking-back "(\\=")
         (progn
           (message "Nothing more to thread.")
           nil)
@@ -1641,7 +1641,7 @@ This function only does the actual removal."
 
 (defun cljr--find-symbol-at-point ()
   (save-excursion
-    (when (looking-back "\\s_\\|\\sw" 1)
+    (when (looking-back "\\s_\\=\\|\\sw\\=")
       (paredit-backward))
     (let ((beg (point)))
       (paredit-forward)
@@ -1677,7 +1677,7 @@ This function only does the actual removal."
       (paredit-forward-up)
       (when (re-search-forward (regexp-opt (list symbol) 'symbols) bound t)
         (setq include-as t)))
-    (when (looking-back "\\s_\\|\\sw" 1)
+    (when (looking-back "\\s_\\=\\|\\sw\\=")
       (paredit-backward))
     (kill-sexp)
     (insert "{:keys [" (s-join " " (-distinct (reverse symbols))) "]"
@@ -1785,7 +1785,7 @@ This function only does the actual removal."
   "Like paredit-raise-sexp, but removes # in front of function literals and sets."
   (interactive "P")
   (paredit-raise-sexp argument)
-  (when (looking-back " #" 2)
+  (when (looking-back " #\\=")
     (delete-char -1)))
 
 ;;;###autoload
@@ -1794,7 +1794,7 @@ This function only does the actual removal."
 front of function literals and sets."
   (interactive "P")
   (paredit-splice-sexp-killing-backward argument)
-  (when (looking-back " #" 2)
+  (when (looking-back " #\\=")
     (delete-char -1)))
 
 ;;;###autoload
@@ -1804,7 +1804,7 @@ front of function literals and sets."
   (interactive "P")
   (save-excursion
     (paredit-backward-up)
-    (when (looking-back " #" 2)
+    (when (looking-back " #\\=")
       (delete-char -1)))
   (paredit-splice-sexp-killing-forward argument))
 
@@ -1925,7 +1925,7 @@ sorts the project's dependency vectors."
       (re-search-forward dividing-line)
       (re-search-forward (s-concat "\\[" dep "\\s-+\""))
       (paredit-backward-up 2)
-      (while (not (looking-back "^\\s-*"))
+      (while (not (looking-back "^\\s-*\\="))
         (forward-char -1))
       (while (save-excursion (forward-line -1) (cljr--comment-line?))
         (forward-line -1))
@@ -2202,7 +2202,7 @@ Signal an error if it is not supported."
   (paredit-forward-down)
   (paredit-forward 2)
   (paredit-backward-down)
-  (if (looking-back "\\[")
+  (if (looking-back "\\[\\=")
       (insert param)
     (insert " " param)))
 
@@ -2646,7 +2646,7 @@ Defaults to the dependency vector at point, but prompts if none is found."
   (let ((sexp-regexp (rx (or "(" "#{" "{" "["))))
     (unless (looking-at sexp-regexp)
       (paredit-backward-up))
-    (when (looking-back "#")
+    (when (looking-back "#\\=")
       (forward-char -1))))
 
 ;;;###autoload
@@ -2789,7 +2789,7 @@ Defaults to the dependency vector at point, but prompts if none is found."
         (goto-char (point-min))
         (forward-line (1- line-beg))
         (forward-char (1- col-beg))
-        (let* ((call-site? (looking-back "(\s*"))
+        (let* ((call-site? (looking-back "(\s*\\="))
                (sexp (if call-site?
                          (prog1 (cljr--extract-sexp-as-list)
                            (paredit-backward-up)


### PR DESCRIPTION
- LIMIT is not how far you want to look back, but the buffer position to
  stop looking.
- Instead of using any LIMIT parameter, "\=" can be used to anchor at
  point.