### PR TITLE
[Fix #188] Make promote-fn aware of locals

### DIFF
--- a/features/promote-function.feature
+++ b/features/promote-function.feature
@@ -6,6 +6,7 @@ Feature: Tests for some minor features
     And I open file "tmp/src/cljr/core.clj"
     And I clear the buffer
     And I don't use multiple-cursors
+    And I mock out the call to the middleware to find locals
 
   Scenario: Promote fn to defn
     When I insert:
@@ -130,4 +131,29 @@ Feature: Tests for some minor features
                        (map (fn [x] (do-stuff x)) (range idx))))
               {}
               (map-indexed vector cells)))
+    """
+
+  Scenario: Promote fn capturing locals
+    When I insert:
+    """
+    (let [foo 1
+          bar 2]
+      (map (fn [n] (+ foo bar n)) [1 2 3]))
+    """
+    And I place the cursor after "fn"
+    And The middleware is mocked to return foo bar as locals
+    And I start an action chain
+    And I press "C-! pf"
+    And I type "foobar-adder"
+    And I press "RET"
+    And I execute the action chain
+    Then I should see:
+    """
+    (defn- foobar-adder
+      [foo bar n]
+      (+ foo bar n))
+
+    (let [foo 1
+          bar 2]
+      (map (partial foobar-adder foo bar) [1 2 3]))
     """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -226,3 +226,13 @@
 :match \"(map my-inc (range 10))\"})}")))
            (cljr--inline-symbol "fake-ns" (gethash :definition response)
                                 (gethash :occurrences response)))))
+
+(And "I mock out the call to the middleware to find locals$"
+     (lambda ()
+       (defun cljr--call-middleware-to-find-unbound-vars (file line column)
+         "")))
+
+(And "The middleware is mocked to return foo bar as locals$"
+     (lambda ()
+       (defun cljr--call-middleware-to-find-unbound-vars (file line column)
+         "foo bar")))


### PR DESCRIPTION
The old version would not take captured locals into account when
functions were promoted to toplevel forms.