### PR TITLE
`sn`: Improve cljr-sort-ns

### DIFF
--- a/features/sort-ns.feature
+++ b/features/sort-ns.feature
@@ -24,6 +24,40 @@ Feature: Sort ns form
     """
     And I place the cursor before "Calendar"
     And I press "C-! sn"
+    Then The buffer should be modified
+    Then I should see:
+    """
+    (ns ^{:doc "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore (et dolore magna aliqua)."}
+      furtive.runtime.session.bucket
+      (:use clojure.string
+            clojure.test)
+      (:require [clj-time.core :as clj-time]
+                [foo.bar :refer :all])
+      (:import (java.nio.charset Charset)
+               (java.security MessageDigest)
+               java.util.Calendar
+               [org.joda.time DateTime]))
+    """
+  Scenario: Sort ns that already sorted
+    When I insert:
+    """
+    (ns ^{:doc "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore (et dolore magna aliqua)."}
+      furtive.runtime.session.bucket
+      (:use clojure.string
+            clojure.test)
+      (:require [clj-time.core :as clj-time]
+                [foo.bar :refer :all])
+      (:import (java.nio.charset Charset)
+               (java.security MessageDigest)
+               java.util.Calendar
+               [org.joda.time DateTime]))
+    """
+    And I place the cursor before "Calendar"
+    And I save the file
+    And I press "C-! sn"
+    Then The buffer should not be modified
     Then I should see:
     """
     (ns ^{:doc "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -344,3 +344,15 @@
 (When "I kill the \"\\(.+\\)\" buffer"
       (lambda (buffer)
         (kill-buffer buffer)))
+
+(And "^I save the file$"
+     (lambda ()
+       (save-buffer)))
+
+(Then "^The buffer should be modified$"
+      (lambda ()
+        (assert (buffer-modified-p))))
+
+(Then "^The buffer should not be modified$"
+      (lambda ()
+        (assert (not (buffer-modified-p)))))


### PR DESCRIPTION
There are no changes actually, but the buffer has been changed.
when I sort the ns which already sorted.

so If not changed actually, clean the modified flag of buffer.