### PR TITLE
[#Fix 217] Parameterise auto-ns test declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+- [#217](https://github.com/clojure-emacs/clj-refactor.el/issues/217)When requiring the test framework in test files stop favoring `:refer :all`.
+- [#217](https://github.com/clojure-emacs/clj-refactor.el/issues/217)Add a bunch of defcustoms to paramterise what gets inserted into the test namespaces for the various test frameworks.
 - [#216](https://github.com/clojure-emacs/clj-refactor.el/issues/216) Teach our automatic ns generator about cljc files.
 - Teach `cljr-extract-constant` about the `^:const` hint to the compiler.
 - Use yasnippet for placeholder parameters in `cljr-create-fn-from-example`

--- a/features/auto-ns.feature
+++ b/features/auto-ns.feature
@@ -13,8 +13,8 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.core-test
-      (:require [cljr.core :refer :all]
-                [clojure.test :refer :all]))
+      (:require [cljr.core :as sut]
+                [clojure.test :as t]))
     """
 
   Scenario: Test file with foo_ prefix
@@ -22,8 +22,8 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.foo-core
-      (:require [cljr.core :refer :all]
-                [clojure.test :refer :all]))
+      (:require [cljr.core :as sut]
+                [clojure.test :as t]))
     """
 
  Scenario: Test file with _bar suffix
@@ -31,8 +31,8 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.core-bar
-      (:require [cljr.core :refer :all]
-                [clojure.test :refer :all]))
+      (:require [cljr.core :as sut]
+                [clojure.test :as t]))
     """
 
   Scenario: Midje
@@ -46,8 +46,8 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.core-test
-      (:require [cljr.core :refer :all]
-                [midje.sweet :refer :all]))
+      (:require [cljr.core :as sut]
+                [midje.sweet :as midje]))
     """
 
   Scenario: Midje with t_ prefix
@@ -61,8 +61,8 @@ Feature: Add namespace to blank .clj files
     Then I should see:
     """
     (ns cljr.t-core
-      (:require [cljr.core :refer :all]
-                [midje.sweet :refer :all]))
+      (:require [cljr.core :as sut]
+                [midje.sweet :as midje]))
     """
 
   Scenario: cljc file


### PR DESCRIPTION
- Bunch of new defcustoms: `cljr-midje-test-declaration`,
  `clj-expectations-test-declarations`,
  `cljr-cljc-clojure-test-declarations` and
  `cljr-clojure-test-declarations`.
- Default is no longer `:refer :all` anywhere.
- Require `expectations :as e`
- Require `clojure.test :as t`
- Require `midje.sweet :as midje`

`:refer :all` is a generally frowned upon now and it's not available in
cljs so in a world of cljc these are likely to be less and less used
now.

If the user is unhappy with our choice of aliases for their test
namespaces they can override them using the new defcustoms.