### PR TITLE
[Fix #215] Add middleware op for magic requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Up next
 
+- [#215](https://github.com/clojure-emacs/clj-refactor.el/issues/215)Improve the magic requires feature (when you hit `/`) by asking the middleware for all available namespace aliases.
 - Add `cljr-extract-def` which extracts the form at, or around, point as a def.
 - Add `cljr-change-function-signature` to re-order or re-name function parameters.
 - Keep pressing `l` after `cljr-expand-let` to expand further.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -253,6 +253,7 @@ namespace in the project."
 (defvar cljr--change-signature-buffer "*cljr-change-signature*")
 (defvar cljr--manual-intervention-buffer "*cljr-manual-intervention*")
 (defvar cljr--find-symbol-buffer "*cljr-find-usages*")
+(defvar cljr--namespace-aliases-cache nil)
 
 ;;; Buffer Local Declarations
 
@@ -2109,8 +2110,35 @@ front of function literals and sets."
 
 ;; ------ magic requires -------
 
+(defun cljr--clj-file? (&optional buf)
+  "Is BUF, or the current buffer, visiting a clj file?"
+  (s-ends-with? ".clj" (buffer-file-name (or buf (current-buffer)))))
+
 (defun cljr--magic-requires-re ()
-  (concat "(\\(" (regexp-opt (-map 'car cljr-magic-require-namespaces)) "\\)/"))
+  (regexp-opt (-map 'car cljr-magic-require-namespaces)))
+
+(defun cljr--clj-context? ()
+  "Is point in a cljs context?"
+  (or (cljr--clj-file?)
+      ;; TODO check for context within a reader conditional
+      ;; perhaps these class of functions belong in `clojure-mode'
+      ))
+
+(defun cljr--magic-requires-lookup-alias ()
+  "Return (alias (ns.candidate candidate.ns)) if we recognize
+the alias in the project."
+  (let ((short (buffer-substring-no-properties
+                (cljr--point-after 'paredit-backward)
+                (1- (point)))))
+    (if (s-matches? (cljr--magic-requires-re) short)
+        (list short
+              (list (aget cljr-magic-require-namespaces short)))
+      (-when-let (aliases (and cljr--namespace-aliases-cache
+                               (if (cljr--clj-context?)
+                                   (gethash :clj cljr--namespace-aliases-cache)
+                                 (gethash :cljs cljr--namespace-aliases-cache))))
+        (-when-let (candidates (gethash (intern short) aliases))
+          (list short candidates))))))
 
 ;;;###autoload
 (defun cljr-slash ()
@@ -2121,16 +2149,19 @@ command will add the corresponding require statement to the ns
 form."
   (interactive)
   (insert "/")
-  (when (and cljr-magic-requires
-             (looking-back (cljr--magic-requires-re) (point-at-bol)))
-    (let* ((short (match-string-no-properties 1))
-           (long (aget cljr-magic-require-namespaces short)))
+  (-when-let (aliases (and cljr-magic-requires
+                           (cljr--magic-requires-lookup-alias)))
+    (let* ((short (first aliases))
+           (long (cljr--prompt-user-for "Require " (second aliases))))
       (if (and (not (cljr--in-namespace-declaration? (concat ":as " short)))
                (or (not (eq :prompt cljr-magic-requires))
+                   (not (> (length (second aliases)) 1)) ; already prompted
                    (yes-or-no-p (format "Add %s :as %s to requires?" long short))))
           (save-excursion
             (cljr--insert-in-ns ":require")
-            (insert (format "[%s :as %s]" long short))
+            (let ((libspec (format "[%s :as %s]" long short)))
+              (insert libspec)
+              (message "Required %s" libspec))
             (cljr--maybe-sort-ns))))))
 
 (defun aget (map key)
@@ -2367,8 +2398,14 @@ before non-empty. This lets 1.7.0 be sorted above 1.7.0-RC1."
       (error "Empty version list received from middleware!"))))
 
 (defun cljr--prompt-user-for (prompt &optional choices)
+  "Prompt the user with PROMPT.
+
+If CHOICES is provided provide a completed read among the
+possible choices. If the choice is trivial, return it."
   (if choices
-      (completing-read prompt choices)
+      (if (= (length choices) 1)
+          (first choices)
+        (completing-read prompt choices))
     (read-from-minibuffer prompt)))
 
 (defun cljr--add-project-dependency (artifact version)
@@ -2763,6 +2800,16 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-rename-symbol"
     (paredit-forward)
     (cljr--just-one-blank-line)))
 
+(defun cljr--update-namespace-aliases-cache-async ()
+  "Update the contents of `cljr--namespace-aliases-cache'."
+  (cljr--call-middleware-async
+   (list "op" "namespace-aliases")
+   (lambda (response)
+     (ignore-errors
+       (cljr--maybe-rethrow-error response) ; abort; best effort
+       (setq cljr--namespace-aliases-cache
+             (edn-read (nrepl-dict-get response "namespace-aliases")))))))
+
 ;;;###autoload
 (defun cljr-clean-ns ()
   "Clean the ns form for the current buffer.
@@ -2786,16 +2833,14 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-clean-ns"
                         "path" path-to-file))))
     (cljr--maybe-rethrow-error result)
     (-when-let (new-ns (nrepl-dict-get result "ns"))
-      (cljr--replace-ns new-ns))))
+      (cljr--replace-ns new-ns))
+    (cljr--update-namespace-aliases-cache-async)))
 
 (defun cljr--narrow-candidates (candidates symbol)
-  (cond ((= (length candidates) 0)
-         (message "Couldn't find any symbols matching %s on classpath."
-                  (cljr--symbol-suffix symbol)))
-        ((= (length candidates) 1)
-         (car candidates))
-        (t
-         (cljr--prompt-user-for "Require: " candidates))))
+  (if (= (length candidates) 0)
+      (error "Couldn't find any symbols matching %s on classpath."
+             (cljr--symbol-suffix symbol))
+    (cljr--prompt-user-for "Require: " candidates)))
 
 (defun cljr--insert-libspec-verbosely (libspec)
   (insert libspec)
@@ -3294,7 +3339,8 @@ You can mute this warning by changing cljr-suppress-middleware-warnings."
     (when cljr-populate-artifact-cache-on-startup
       (cljr--update-artifact-cache))
     (when cljr-eagerly-build-asts-on-startup
-      (cljr--warm-ast-cache))))
+      (cljr--warm-ast-cache))
+    (cljr--update-namespace-aliases-cache-async)))
 
 (defvar cljr--list-fold-function-names
   '("map" "mapv" "pmap" "keep" "mapcat" "filter" "remove" "take-while" "drop-while"

--- a/features/magic-requires.feature
+++ b/features/magic-requires.feature
@@ -22,3 +22,26 @@ Feature: Magic requires
 
     (set/union)
     """
+
+  Scenario: Require is inserted automagically after getting suggestions from middleware
+    When I insert:
+    """
+    (ns cljr.core)
+
+    (util)
+    """
+    And the cache of namespace aliases is populated
+    And I place the cursor after "util"
+    And I start an action chain
+    And I type "/"
+    And I type "refactor-nrepl.util"
+    And I press "RET"
+    And I type "get-last-sexp"
+    And I execute the action chain
+    Then I should see:
+    """
+    (ns cljr.core
+      (:require [refactor-nrepl.util :as util]))
+
+    (util/get-last-sexp)
+    """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -345,6 +345,16 @@
            (cljr--change-function-signature (list (cl-second cljr--test-occurrences))
                                             cljr--baz-renamed-to-qux))))
 
+(Given "The cache of namespace aliases is populated"
+       (lambda ()
+         (setq cljr--namespace-aliases-cache
+               (edn-read "{:clj {t (clojure.test)
+set (clojure.set)
+util (refactor-nrepl.util clojure.tools.analyzer.jvm.utils)
+readers (clojure.tools.reader.reader-types) }
+:cljs {set (clojure.set)
+pprint (cljs.pprint)}}"))))
+
 (When "I kill the \"\\(.+\\)\" buffer"
       (lambda (buffer)
         (kill-buffer buffer)))


### PR DESCRIPTION
- Without middleware everything works as before.
- `cljr-magic-require-namespaces` is now more of a seed value and if the
  middleware is active only plays a role in new projects.
- On ambiguous aliases we prompt for resolution.  Hopefully this will drive
  users to pick unique aliases which improves readability.
- We keep a cache of aliases around, to keep things snappy.  On larger
  projects the aliases are probably fairly stable.
- The cache is updated,async, on repl init and everytime `clean-ns` is called.

If the caching proves to be annoying we can change this easily to be a
sync request for fresh data. If *that* proves too slow we can also
easily cache the alias data in the middleware so we don't gather alias
data from files that are unchanged since last scan.