### PR TITLE
Properly return other build tools' project files if project.clj is missing

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -794,16 +794,18 @@ A new record is created to define this constructor."
          (locate-dominating-file default-directory "project.clj")))
       (ignore-errors
         (file-truename
-         (locate-dominating-file default-directory "boot.clj")))
+         (locate-dominating-file default-directory "build.boot")))
       (ignore-errors (file-truename
                       (locate-dominating-file default-directory "pom.xml")))))
 
 (defun cljr--project-file ()
-  (or (ignore-errors
-        (expand-file-name "project.clj" (cljr--project-dir)))
-      (ignore-errors
-        (expand-file-name "boot.clj" (cljr--project-dir)))
-      (ignore-errors (expand-file-name "pom.xml" (cljr--project-dir)))))
+  (let ((project-dir (cljr--project-dir)))
+    (or (let ((file (expand-file-name "project.clj" project-dir)))
+          (and (file-exists-p file) file))
+        (let ((file (expand-file-name "build.boot" project-dir)))
+          (and (file-exists-p file) file))
+        (let ((file (expand-file-name "pom.xml" project-dir)))
+          (and (file-exists-p file) file)))))
 
 (defun cljr--project-files ()
   (split-string (shell-command-to-string


### PR DESCRIPTION
`cljr--project-file` always returned `project.clj` if `pom.xml` or `boot.clj` was present.

Also, change `boot.clj` to `build.boot` because AFAIK the latter is the default one.