### PR TITLE
Replace refer all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Up next
 
+- Replace `:refer :all` style require with alias or optionally with list of referred syms style require.
+
 ### Changes
 
 - Compatible with CIDER 0.11
 - Follow up CIDER 0.11 injecting its own dependencies at `cider-jack-in` by adding clj-refactor's own dependencies to the approriate vars in CIDER. Both leiningen and boot are supported. Set `cljr-inject-dependencies-at-jack-in` to nil to opt out.
+- Add macro-occurrence cache. If warming this cache at REPL startup is not preferred set `cljr-eagerly-cache-macro-occurrences-on-startup` to nil.
+
 
 ## 2.0.0
 

--- a/features/replace-refer-all.feature
+++ b/features/replace-refer-all.feature
@@ -1,0 +1,51 @@
+Feature: replace refer all with referred list or aliases
+
+  Background:
+    Given I have a project "example" in "tmp"
+    And I have a clojure-file "tmp/src/example/one.clj"
+    When I open file "tmp/src/example/one.clj"
+    And I clear the buffer
+    And I press "M->"
+    And I insert:
+    """
+    (ns example.one
+      (:require [example.two :refer :all]))
+
+    (defn bar []
+      (str "bar" (foo) "goo"))
+
+    (defn sky []
+      (str "sky: " (star*)))
+    """
+    And I press "C-x C-s"
+    And I press "C-x k"
+
+  Scenario: replace refer all with referred list
+    Given I open file "tmp/src/example/one.clj"
+    And I call replace refer all with referred list with mock data for "example.two"
+    Then I should see:
+    """
+    (ns example.one
+      (:require [example.two :refer [foo star*]]))
+
+    (defn bar []
+      (str "bar" (foo) "goo"))
+
+    (defn sky []
+      (str "sky: " (star*)))
+    """
+
+  Scenario: replace refer all with aliased refer
+    Given I open file "tmp/src/example/one.clj"
+    And I call replace refer all with alias with mock data for "example.two"
+    Then I should see:
+    """
+    (ns example.one
+      (:require [example.two :as two]))
+
+    (defn bar []
+      (str "bar" (two/foo) "goo"))
+
+    (defn sky []
+      (str "sky: " (two/star*)))
+    """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -403,6 +403,21 @@ pprint (cljs.pprint)}}"))))
       (lambda ()
         (validate-all-helpers)))
 
+(Given "^I call replace refer all with referred list with mock data for \"\\(.*\\)\"$"
+       (lambda (ns-name)
+         (cljr--replace-refer-all-with-referred-syms
+          ns-name
+          (edn-read
+           "({:line-beg 5 :line-end 5 :col-beg 13 :col-end 16 :file\"tmp/src/example/one.clj\" :name \"foo\"} {:line-beg 8 :line-end 8 :col-beg 15 :col-end 20 :file \"tmp/src/example/one.clj\" :name \"star*\"})"))))
+
+(Given "^I call replace refer all with alias with mock data for \"\\(.*\\)\"$"
+       (lambda (ns-name)
+         (cljr--replace-refer-all-with-alias
+          ns-name
+          (edn-read
+           "({:line-beg 5 :line-end 5 :col-beg 13 :col-end 30 :file\"one.clj\" :name \"foo\"} {:line-beg 8 :line-end 8 :col-beg 15 :col-end 28 :file \"one.clj\" :name \"star*\"})")
+          "two")))
+
 (Given "^I call find usages for \"\\(.*\\)\"$"
        (lambda (symbol-name)
          (cljr--setup-find-symbol-buffer symbol-name)


### PR DESCRIPTION
Replace :refer :all style require with alias style require or
optionally (with prefix) referred names style require.

- with prefix cljr--replace-refer-all-with-referred-list still available
- add keybinding for cljr-replace-refer-all
- add cljr-replace-refer-all to the ns hydras
- add warm-macro-occurrences-cache
- defcustom to warm-macro-occurrences-cache at startup

clojure-emacs/refactor-nrepl#135 provides the middleware backend function

Intended to be merged for version 2.1.0