### PR TITLE
[Fix #266] Add prefix variant to `ar`, `ai` and `au`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Up next
 
+- Add prefix variant to `cljr-add-import-to-ns` for insertion of imports in the cljs part of the ns declaration.
+- Add prefix variant to `cljr-add-use-to-ns` for insertion of 'use' in the cljs part of the ns declaration.
+- Add prefix variant to `cljr-add-require` for insertion of requires in the cljs part of the ns declaration.
 - Boot support for `cljr-clean-ns`.
 - Boot support for `cljr-sort-project-dependencies`.
 - Boot support for `cljr-update-project-dependencies`.

--- a/features/add-to-ns.feature
+++ b/features/add-to-ns.feature
@@ -25,6 +25,38 @@ Feature: Add to namespace
                 [clojure.string :as s]))
     """
 
+  Scenario: Add require to cljs part of cljc namespace
+    When I clear the buffer
+    And I insert:
+    """
+    (ns cljr.core
+      #?@(:clj
+          [(:require
+            [clj-time.core :refer :all]
+            [clojure.string :as s])]
+          :cljs
+          [(:require
+            [cljs-time.core :refer :all])]))
+    """
+    And I press "C-u C-! ar"
+    And I press "TAB"
+    And I press "TAB"
+    And I type "cljs.string"
+    And I press "TAB"
+    And I type "s"
+    Then I should see:
+    """
+    (ns cljr.core
+      #?@(:clj
+          [(:require
+            [clj-time.core :refer :all]
+            [clojure.string :as s])]
+          :cljs
+          [(:require
+            [cljs-time.core :refer :all]
+            [cljs.string :as s])]))
+    """
+
   Scenario: Add use to namespace
     When I press "C-! au"
     And I type "clj-time.core"
@@ -42,6 +74,36 @@ Feature: Add to namespace
                 [clojure.string :refer [join]]))
     """
 
+  Scenario: Add use to cljs part of cljc namespace
+    When I clear the buffer
+    And I insert:
+    """
+    (ns cljr.core
+      #?@(:clj
+          [(:require
+            [clj-time.core :refer :all]
+            [clojure.string :as s])]
+          :cljs
+          [(:require
+            [cljs.string :refer :all])]))
+    """
+    When I press "C-u C-! au"
+    And I type "cljs-time.core"
+    And I press "TAB"
+    And I press ":all"
+    Then I should see:
+    """
+    (ns cljr.core
+      #?@(:clj
+          [(:require
+            [clj-time.core :refer :all]
+            [clojure.string :as s])]
+          :cljs
+          [(:require
+            [cljs.string :refer :all]
+            [cljs-time.core :refer :all])]))
+    """
+
   Scenario: Add import to namespace
     When I press "C-! ai"
     And I type "java.io.File"
@@ -53,4 +115,35 @@ Feature: Add to namespace
     (ns cljr.core
       (:import java.io.File
                [java.util Date]))
+    """
+
+  Scenario: Add import to cljs part of cljc namespace
+    When I clear the buffer
+    And I insert:
+    """
+    (ns cljr.core
+      #?@(:clj
+          [(:require
+            [clj-time.core :refer :all]
+            [clojure.string :as s])
+           (:import java.util.Date)]
+          :cljs
+          [(:require
+            [cljs.string :refer :all])]))
+    """
+    When I press "C-u C-! ai"
+    And I type "goog.string"
+    And I press "TAB"
+    Then I should see:
+    """
+    (ns cljr.core
+      #?@(:clj
+          [(:require
+            [clj-time.core :refer :all]
+            [clojure.string :as s])
+           (:import java.util.Date)]
+          :cljs
+          [(:require
+            [cljs.string :refer :all])
+           (:import goog.string)]))
     """


### PR DESCRIPTION
The prefix variant acts on the cljs part of the cljc ns.  The non-prefix
version works like before and just acts on whatever the first search hit
for matches.