### PR TITLE
cljr-add-ns-to-blank-clj-files: use cider-expected-ns if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Up next
 
+- When inserting ns form to blank clojure-ish file, check if cider is available and connected for better detecting the expected namespace.
+
 ## 2.2.0
 
 - Smarten up `cljr-stop-referring` to replace `:refer :all` style require with alias and apply the alias to all occurrences of symbols from the referred namespace.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1058,8 +1058,7 @@ word test in it and whether the file lives under the test/ directory."
     (when (and cljr-add-ns-to-blank-clj-files
                (cljr--clojure-ish-filename-p (buffer-file-name))
                (= (point-min) (point-max)))
-      (clojure-insert-ns-form)
-      (newline 2)
+      (insert (format "(ns %s)\n\n" (cider-expected-ns)))
       (when (cljr--in-tests-p)
         (cljr--add-test-declarations)))))
 


### PR DESCRIPTION
(See clojure-emacs/clojure-mode#372 and clojure-emacs/cider#1622 for context.)

This is the "simple dirty fix" until we migrate the namespace insertion code from clj-refactor to cider.

A side benefit of having both the `clojure-expected-ns` (filesystem heuristic for guessing the namespace) and `cider-expected-ns` (searching the classpath), is that we can use the former when cider is not connected.

I didn't add any tests for the new functionality becuase (a) it's a temp fix and (b) I don't see any tests for clj-refactor.el (are they hiding somewhere nonobvious?).  In any case, I tested it locally with emacs-24.5.1, cider-20160323.1057, and clojure-mode-20160314.2147.