### PR TITLE
Add github templates for issues, PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 # Contributing
 
-If you discover issues, have ideas for improvements or new features,
-please report them to the [issue tracker][1] of the repository or
-submit a pull request. Please, try to follow these guidelines when you do so.
+Do you have an issue to report or an idea to submit? That's great!
+We're eager to make clj-refactor better. Please report issues to
+the [issue tracker][1] of the repository or submit a pull request.
+
+To help us, please, follow these guidelines:
 
 ## Issue reporting
 
@@ -10,9 +12,10 @@ submit a pull request. Please, try to follow these guidelines when you do so.
 * Check that the issue has not already been fixed in the latest code
   (a.k.a. `master`).
 * Be clear, concise and precise in your description of the problem.
-* Open an issue with a descriptive title and a summary in grammatically correct, complete sentences.
-* Mention your Emacs version and operating system.
 * Mention the version you're running. You can call `cljr-version` to obtain this information.
+* Mention the CIDER version you're running.
+* Mention the leiningen or boot version you're using.
+* Mention your Emacs version and operating system.
 * Include any relevant code to the issue summary.
 
 ## Pull requests
@@ -23,7 +26,6 @@ submit a pull request. Please, try to follow these guidelines when you do so.
 * Mention related tickets in the commit messages (e.g. `[Fix #N] Add command ...`)
 * Update the [changelog][6].
 * Use the same coding conventions as the rest of the project.
-* Verify your Emacs Lisp code with `checkdoc` (<kbd>C-c ? d</kbd>).
 * [Squash related commits together][5].
 * Open a [pull request][4] that relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,44 @@
+*Use the template below when reporting bugs. Please, make sure that
+you're running the latest stable clj-refactor.el and that the problem
+you're reporting hasn't been reported (and potentially fixed) already.*
+
+*When requesting new features or improvements to existing features you can
+discard the template completely. Just make sure to make a good case for your
+request.*
+
+**Remove all of the placeholder text in your final report!**
+
+## Expected behavior
+
+## Actual behavior
+
+## Steps to reproduce the problem
+
+*This is extremely important! Providing us with a reliable way to reproduce
+a problem will expedite its solution.*
+
+## Environment & Version information
+
+### clj-refactor.el version information
+
+*You can call `cljr-version` to obtain this information.*
+
+### CIDER version information
+
+*Include here the version string displayed when
+CIDER's REPL is launched. Here's an example:*
+
+```
+;; CIDER 0.12.0snapshot (package: 20160331.421), nREPL 0.2.12
+;; Clojure 1.8.0, Java 1.8.0_31
+```
+
+### Leiningen or Boot version
+
+### Emacs version
+
+*E.g. 24.5* (use <kbd>M-x emacs-version</kbd> to check it if unsure)
+
+### Operating system
+
+*E.g. Fedora 23, OS X 10.11 "El Capitan", Windows 10, etc*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Before submitting a PR make sure the following things have been done (and denote this
+by checking the relevant checkboxes):
+
+- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
+- [ ] You've added tests (if possible) to cover your change(s)
+- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
+- [ ] All tests are passing (run `./run-tests.sh`)
+- [ ] You've updated the changelog (if adding/changing user-visible functionality)
+- [ ] You've updated the readme (if adding/changing user-visible functionality)
+
+Thanks!


### PR DESCRIPTION
templates are slightly modified versions of the ones used for
CIDER. CONTRIBUTING.md is also moved to the `.github` directory.