### PR TITLE
Give `ad` a prefix variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Up next
 
+- [#301] (https://github.com/clojure-emacs/clj-refactor.el/issues/301) `ad`  has gained a prefix to declare the symbol under the cursor.
 - [#312](https://github.com/clojure-emacs/clj-refactor.el/issues/312) Allow `sut` alias to be customized.
 - [#305](https://github.com/clojure-emacs/clj-refactor.el/issues/305) Don't call lookup-alias for non namespaced keywords at all when slash is typed. However trigger lookup alias with the leading :: stripped off the prefix if the keyword is namespaced.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1430,23 +1430,28 @@ optionally including those that are declared private."
     (re-search-backward def (cljr--point-after 'paredit-backward) :no-error)))
 
 (defun cljr--add-declaration (def)
-  (cljr--goto-declare)
-  (backward-char)
-  (insert " " def)
-  (cljr--post-command-message "Added declaration for %s" def))
+  (when (cljr--already-declared-p def)
+    (user-error "%s is already declared" def))
+  (save-excursion
+    (cljr--goto-declare)
+    (backward-char)
+    (insert " " def)
+    (cljr--post-command-message "Added declaration for %s" def)))
 
 ;;;###autoload
-(defun cljr-add-declaration ()
+(defun cljr-add-declaration (for-thing-at-point-p)
   "Add a declare for the current def near the top of the buffer.
 
+With a prefix add a declaration for the symbol under the cursor instead.
+
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-declaration"
-  (interactive)
-  (save-excursion
-    (-if-let (def (cljr--name-of-current-def))
-        (if (cljr--already-declared-p def)
-            (user-error "%s is already declared" def)
-          (cljr--add-declaration def))
-      (user-error "Not inside a def form."))))
+  (interactive "P")
+  (if for-thing-at-point-p
+      (cljr--add-declaration (cider-symbol-at-point))
+    (save-excursion
+      (-if-let (def (cljr--name-of-current-def))
+          (cljr--add-declaration def)
+        (user-error "Not inside a def form.")))))
 
 ;; ------ extract constant ----------------
 

--- a/features/add-declaration.feature
+++ b/features/add-declaration.feature
@@ -71,3 +71,21 @@ Feature: Declare current top-level form
       [a b]
       (+ a b))
     """
+
+  Scenario: Declare the thing at point
+    When I insert:
+    """
+    (ns cljr.core)
+
+    (foo :bar)
+    """
+    And I place the cursor before " :bar"
+    And I press "C-u C-! ad"
+    Then I should see:
+    """
+    (ns cljr.core)
+
+    (declare foo)
+
+    (foo :bar)
+    """


### PR DESCRIPTION
The new prefix variant can be used to declare the thing at point,
instead of the surrounding def.

This is useful for the times when you've just written, or am about to
write, the name of a symbol occuring later in the file.
