### PR TITLE
Enhance `ad` to declare thing at point outside def

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1446,12 +1446,10 @@ With a prefix add a declaration for the symbol under the cursor instead.
 
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-declaration"
   (interactive "P")
-  (if for-thing-at-point-p
-      (cljr--add-declaration (cider-symbol-at-point))
-    (save-excursion
-      (-if-let (def (cljr--name-of-current-def))
-          (cljr--add-declaration def)
-        (user-error "Not inside a def form.")))))
+  (-if-let (def (and (not for-thing-at-point-p)
+                     (save-excursion (cljr--name-of-current-def))))
+      (cljr--add-declaration def)
+    (cljr--add-declaration (cider-symbol-at-point))))
 
 ;; ------ extract constant ----------------
 

--- a/features/add-declaration.feature
+++ b/features/add-declaration.feature
@@ -72,7 +72,7 @@ Feature: Declare current top-level form
       (+ a b))
     """
 
-  Scenario: Declare the thing at point
+  Scenario: Declare the thing at point if outside a def
     When I insert:
     """
     (ns cljr.core)
@@ -80,7 +80,7 @@ Feature: Declare current top-level form
     (foo :bar)
     """
     And I place the cursor before " :bar"
-    And I press "C-u C-! ad"
+    And I press "C-! ad"
     Then I should see:
     """
     (ns cljr.core)
@@ -88,4 +88,28 @@ Feature: Declare current top-level form
     (declare foo)
 
     (foo :bar)
+    """
+
+  Scenario: Declare the thing at point if inside a def
+    When I insert:
+    """
+    (ns cljr.core)
+
+    (declare foo)
+
+    (defn- ^{:meta :data} add
+      [a b]
+      (bar a b))
+    """
+    And I place the cursor before " a b"
+    And I press "C-u C-! ad"
+    Then I should see:
+    """
+    (ns cljr.core)
+
+    (declare foo bar)
+
+    (defn- ^{:meta :data} add
+      [a b]
+      (bar a b))
     """


### PR DESCRIPTION
If we are outside a def we default to declare thing at point as
discussed on #325. The prefix is still needed to declare thing at point
if inside a def.