### PR TITLE
Fix that cljr--clojure-filename-p didn't use its arg

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1028,8 +1028,8 @@ word test in it and whether the file lives under the test/ directory."
       (s-ends-with-p ".cljc" file-name)))
 
 (defun cljr--clojure-filename-p (file-name)
-  (or (s-ends-with-p ".clj" (buffer-file-name))
-      (s-ends-with-p ".cljc" (buffer-file-name))))
+  (or (s-ends-with-p ".clj" file-name)
+      (s-ends-with-p ".cljc" file-name)))
 
 (defun cljr--add-ns-if-blank-clj-file ()
   (ignore-errors


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

