### PR TITLE
[Fix #341] Avoid circular dep when using mv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - [#309](https://github.com/clojure-emacs/clj-refactor.el/issues/309)  `am` creates alias for fully-qualified symbols.
 - [#313](https://github.com/clojure-emacs/clj-refactor.el/issues/313)  teach `pf` about function literals using `%&`.
 - [#320](https://github.com/clojure-emacs/clj-refactor.el/issues/320) `*data-readers*` ignored when searching for macros.
-- [#339](https://github.com/clojure-emacs/clj-refactor.el/issues/339) Teach stop refer to understand multiline refer clauses
+- [#339](https://github.com/clojure-emacs/clj-refactor.el/issues/339) Teach stop refer to understand multiline refer clauses.
+- [#341](https://github.com/clojure-emacs/clj-refactor.el/issues/341) Avoid creating circular dependencies with move form when source namespace refers to the target namespace with a require.
 
 ## 2.2.0
 


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
