### PR TITLE
Add space after dashes-to-underscores prompt

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1050,7 +1050,7 @@ word test in it and whether the file lives under the test/ directory."
 
 (defun cljr--maybe-replace-dash-in-file-name (file-name)
   (if (and (cljr--dash-in-file-name-p file-name)
-           (yes-or-no-p "The file name contains dashes. Replace with underscores?"))
+           (yes-or-no-p "The file name contains dashes. Replace with underscores? "))
       (concat (file-name-directory file-name)
               (s-replace "-" "_" (file-name-nondirectory file-name)))
     file-name))


### PR DESCRIPTION
This changes the prompt from "Replace with underscores?(yes or no)" to "Replace with underscores? (yes or no)", which looks more professional.
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
