### PR TITLE
use cl-assert instead of assert

### DIFF
--- a/Cask
+++ b/Cask
@@ -8,4 +8,5 @@
   (depends-on "espuds")
   (depends-on "cider")
   (depends-on "edn")
-  (depends-on "clojure-mode"))
+  (depends-on "clojure-mode")
+  (depends-on "cl-lib"))


### PR DESCRIPTION
clj-refactor.el assumes the 'cl package to be required, as it uses its `assert` macro.
That assumption turns out to be false with my recent version of cider and emacs.

- `M-x emacs-version`
  `GNU Emacs 25.1.1 (x86_64-unknown-linux-gnu, GTK+ Version 3.22.1) of 2016-11-22`
- `M-x cider-version`
  `CIDER 0.14.0 (Berlin)`
- From a clojure file `M-x cider-jack-in`
  ```
  Starting nREPL server via /run/current-system/sw/bin/lein update-in :dependencies conj [org.clojure/tools.nrepl\ \"0.2.12\"\ \:exclusions\ \[org.clojure/clojure\]\] -- update-in :plugins conj \[refactor-nrepl\ \"2.2.0\"\] -- update-in :plugins conj \[cider/cider-nrepl\ \"0.14.0\"\] -- repl :headless...
  nREPL server started on 39893
  [nREPL] Establishing direct connection to localhost:39893 ...
  [nREPL] Direct connection established
  error in process filter: cljr--create-msg: Symbol’s function definition is void: assert
  error in process filter: Symbol’s function definition is void: assert
```