### PR TITLE
Add documentation macro to minor mode for keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Up next
 
+- Display keymap bindings in documentation for minor mode
 - New config setting `cljr-libspec-whitelist` to prevent libspecs which appear unused but are side-effecting at load from being pruned.
 - [#301] (https://github.com/clojure-emacs/clj-refactor.el/issues/301) `ad`  has gained a prefix to declare the symbol under the cursor.
 - [#312](https://github.com/clojure-emacs/clj-refactor.el/issues/312) Allow `sut` alias to be customized.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -3985,7 +3985,9 @@ If injecting the dependencies is not preferred set `cljr-inject-dependencies-at-
 ;; ------ minor mode -----------
 ;;;###autoload
 (define-minor-mode clj-refactor-mode
-  "A mode to keep the clj-refactor keybindings."
+  "A mode to keep the clj-refactor keybindings.
+
+\\{clj-refactor-map}"
   nil " cljr" clj-refactor-map
   (if clj-refactor-mode
       (add-hook 'post-command-hook #'cljr--post-command-hook :append :local)


### PR DESCRIPTION
Inserts the default documentation for keybindings into the output for C-h m or
C-h f clj-refactor-mode. Given all the hydra and other documentation overrides
it might be preferable to link to that, but I think this increases
discover-ability as is.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
~~- [ ] You've added tests (if possible) to cover your change(s)~~
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
~~- [ ] You've updated the readme (if adding/changing user-visible functionality)~~

Thanks!
