### PR TITLE
Change prefix-notation to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [#363](https://github.com/clojure-emacs/clj-refactor.el/issues/363) cljr-favor-prefix-notation by default is set to false
+
 ## Up next
 
 - Display keymap bindings in documentation for minor mode

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -105,7 +105,7 @@ This only applies to dependencies added by `cljr-add-project-dependency'."
   :group 'cljr
   :type 'boolean)
 
-(defcustom cljr-favor-prefix-notation t
+(defcustom cljr-favor-prefix-notation nil
   "If t, `cljr-clean-ns' favors prefix notation in the ns form."
   :group 'cljr
   :type 'boolean)


### PR DESCRIPTION
The reasoning is captured in the issue: https://github.com/clojure-emacs/clj-refactor.el/issues/363

tl;dr: it allows for quicker searching and clj(s|c) files don't support it

-----

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
**This is missing, should I raise it as an issue?**
- [ ] You've added tests (if possible) to cover your change(s)
**Should this be tested?**
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
**I've updated the changelog, but not sure about the headings in the changelog.**
- [ ] You've updated the readme (if adding/changing user-visible functionality)
**Not quite sure what to put in the README about this. Especially as there is a link to the changelog**

Thanks!
