### PR TITLE
[Fix #384] Add cljr-auto-sort-project-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#394](https://github.com/clojure-emacs/clj-refactor.el/issues/394) New config option `cljr-assume-language-context`: by default, when clj-refactor encounters an ambiguous context (clj vs cljs) it creates a popup asking user which context is meant. If this option is changed to "clj" or "cljs", clj-refactor will use that as the assumed context in such ambigous cases.
+- [#384](https://github.com/clojure-emacs/clj-refactor.el/issues/384) Add `cljr-auto-sort-project-dependencies`.
 
 ## 2.3.1
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -58,6 +58,11 @@
   :group 'cljr
   :type 'boolean)
 
+(defcustom cljr-auto-sort-project-dependencies nil
+  "If t, sort project dependencies after any command that changes them."
+  :group 'cljr
+  :type 'boolean)
+
 (defcustom cljr-magic-requires t
   "Whether to automatically require common namespaces when they are used.
 These are the namespaces listed in `cljr-magic-require-namespaces'.
@@ -2183,6 +2188,11 @@ possible choices. If the choice is trivial, return it."
       (paredit-backward-down)
       (cljr-hotload-dependency))))
 
+(defun cljr--maybe-sort-project-dependencies ()
+  "If allowed, sort project dependencies in the current buffer."
+  (when cljr-auto-sort-project-dependencies
+    (cljr-sort-project-dependencies)))
+
 ;;;###autoload
 (defun cljr-add-project-dependency (force)
   "Add a dependency to the project.clj file.
@@ -2194,7 +2204,8 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-project-depe
                          (cljr--prompt-user-for "Artifact: ")))
              (version (thread-last (cljr--get-versions-from-middleware lib-name)
                         (cljr--prompt-user-for "Version: "))))
-    (cljr--add-project-dependency lib-name version)))
+    (cljr--add-project-dependency lib-name version)
+    (cljr--maybe-sort-project-dependencies)))
 
 ;;;###autoload
 (defun cljr-update-project-dependency ()

--- a/features/add-project-dependency.feature
+++ b/features/add-project-dependency.feature
@@ -1,0 +1,58 @@
+Feature: Add project dependencies
+
+  Background:
+    Given I have a project "cljr" in "tmp"
+    And I open file "tmp/project.clj"
+    And I clear the buffer
+
+  Scenario: Add project dependency without sorting
+    When I insert:
+    """
+    (defproject example-project "1.0.0"
+      :description "Example project"
+      :dependencies [[org.clojure/clojure "1.8.0"]
+                     [clj-time "0.12.0"]]
+      :main example-project.core)
+    """
+    And I don't want my project dependencies to be sorted automatically
+    And I start an action chain
+    And I press "C-! ap"
+    And I type "com.github.bdesham/clj-plist"
+    And I press "RET"
+    And I type "0.10.0"
+    And I press "RET"
+    And I execute the action chain
+    Then I should see:
+    """
+    (defproject example-project "1.0.0"
+      :description "Example project"
+      :dependencies [[org.clojure/clojure "1.8.0"]
+                     [clj-time "0.12.0"]
+                     [com.github.bdesham/clj-plist "0.10.0"]]
+      :main example-project.core)
+    """
+
+  Scenario: Add project dependency with sorting
+    When I insert:
+    """
+    (defproject example-project "1.0.0"
+      :description "Example project"
+      :dependencies [[org.clojure/clojure "1.8.0"]
+                     [clj-time "0.12.0"]]
+      :main example-project.core)
+    """
+    And I want my project dependencies to be sorted automatically
+    And I press "C-! ap"
+    And I type "com.github.bdesham/clj-plist"
+    And I press "RET"
+    And I type "0.10.0"
+    And I press "RET"
+    Then I should see:
+    """
+    (defproject example-project "1.0.0"
+      :description "Example project"
+      :dependencies [[clj-time "0.12.0"]
+                     [com.github.bdesham/clj-plist "0.10.0"]
+                     [org.clojure/clojure "1.8.0"]]
+      :main example-project.core)
+    """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -40,6 +40,14 @@
        (lambda ()
          (setq cljr-use-multiple-cursors nil)))
 
+(Given "^I don't want my project dependencies to be sorted automatically"
+       (lambda ()
+         (setq cljr-auto-sort-project-dependencies nil)))
+
+(Given "^I want my project dependencies to be sorted automatically"
+       (lambda ()
+         (setq cljr-auto-sort-project-dependencies t)))
+
 (defun cljr--plist-to-hash (plist)
   (let ((h (make-hash-table)))
     (dolist (k (-filter #'keywordp plist))


### PR DESCRIPTION
* Add new defcustom `cljr-auto-sort-project-dependencies`, defaults to nil.
* Add new function `cljr--maybe-sort-project-dependencies`.
* Call new function from `cljr-add-project-dependency`.
* Update changelog.

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
    -  **No, as existing variable `cljr-auto-sort-ns` was not documented there**


