### PR TITLE
[Fix #391] Add option for disabling warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#394](https://github.com/clojure-emacs/clj-refactor.el/issues/394) New config option `cljr-assume-language-context`: by default, when clj-refactor encounters an ambiguous context (clj vs cljs) it creates a popup asking user which context is meant. If this option is changed to "clj" or "cljs", clj-refactor will use that as the assumed context in such ambigous cases.
+- [#391](https://github.com/clojure-emacs/clj-refactor.el/issues/391) Prevent refactor-nrepl from being injected when starting a REPL outside a project, and add an option `cljr-suppress-outside-project-warning` to suppress the resultant warning.
 
 ## 2.3.1
 


### PR DESCRIPTION
Add `cljr-suppress-outside-project-warning` defcustom. Set `cider-lein-*` variables using advice-driven let-binding instead of global modification, and only inject nrepl-middleware when inside project context. After REPL has started, if outside project context, display more specific warning (unless the new defcustom is set to non-nil).

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
    - **No, as existing warnings were not tested**
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
    - **No, as existing variable `cljr-suppress-middleware-warnings` was not documented there**
