### PR TITLE
Add an option to load all project namespaces at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## NEXT VERSION
+
+### Changes
+ - Add cljr-load-all-project-ns-on-startup option, to help prefill AST cache
+
 ## 2.3.1
 
 - [#363](https://github.com/clojure-emacs/clj-refactor.el/issues/363) cljr-favor-prefix-notation by default is set to false

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -128,6 +128,13 @@ refactorings will use regular prompts instead."
   :group 'cljr
   :type 'boolean)
 
+(defcustom cljr-load-all-project-ns-on-startup nil
+  "If t, the middleware will eagerly load all project namespaces.
+Use this to ensures that all namespaces are loaded before warming
+the AST cache."
+  :group 'cljr
+  :type 'boolean)
+
 (defcustom cljr-populate-artifact-cache-on-startup t
   "If t, the middleware will eagerly populate the artifact cache.
 This makes `cljr-add-project-dependency' as snappy as can be."
@@ -3180,6 +3187,11 @@ You can mute this warning by changing cljr-suppress-middleware-warnings."
   ;; Best effort; don't freak people out with errors
   (ignore-errors
     (when (cljr--middleware-version) ; check if middleware is running
+      (when cljr-load-all-project-ns-on-startup
+        ;; lifted from cider-load-all-project-ns to load without
+        ;; confirmation
+        (let ((loaded-ns-count (length (cider-sync-request:ns-load-all))))
+          (message "Loaded %d namespaces" loaded-ns-count)))
       (when cljr-populate-artifact-cache-on-startup
         (cljr--update-artifact-cache))
       (when (and (not cljr-warn-on-eval)


### PR DESCRIPTION
This ensures the AST cache is populated fully, speeding up
refactorings and prevents some issues when analizing qualified
keywords with aliased namespaces.

Enabling this option makes it unnecessary to manually call
`cider-load-all-project-ns` before running `cljr-find-usages`.

See also: #353

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [*] You've added tests (if possible) to cover your change(s)
   * I tried editing the find-usages.feature, but nothing I do there seems to do make any difference -  I cannot even make the existing tests fail...
  
- [X] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [X] All tests are passing (run `./run-tests.sh`)
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [*] You've updated the readme (if adding/changing user-visible functionality)
  * The related exiting features are all documented on the Wiki and not in the readme, so I've not changed the readme since this feature makes no sense to use on its own.


Thanks!
