### PR TITLE
Let user specify default language context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [#394](https://github.com/clojure-emacs/clj-refactor.el/issues/394) New config option `cljr-assume-language-context`: by default, when clj-refactor encounters an ambiguous context (clj vs cljs) it creates a popup asking user which context is meant. If this option is changed to "clj" or "cljs", clj-refactor will use that as the assumed context in such ambigous cases.
+
 ## 2.3.1
 
 - [#363](https://github.com/clojure-emacs/clj-refactor.el/issues/363) cljr-favor-prefix-notation by default is set to false

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -221,6 +221,13 @@ won't run if there is a broken namespace in the project."
   :group 'cljr
   :type 'boolean)
 
+(defcustom cljr-assume-language-context nil
+  "If set to 'clj' or 'cljs', clj-refactor will use that value in situations
+  where the language context is ambiguous. If set to nil, a popup will be
+  created in each ambiguous case asking user to choose language context."
+  :group 'cljr
+  :type 'string)
+
 (defcustom cljr-libspec-whitelist
   '("^cljsns" "^slingshot.test" "^monger.joda-time" "^monger.json")
   "List of regexes to match against libspec names which shouldn't be pruned.
@@ -1828,11 +1835,15 @@ FEATURE is either :clj or :cljs."
   "Is point in a clj context?"
   (or (cljr--clj-file-p)
       (when (cljr--cljc-file-p)
-        (if (cljr--point-in-reader-conditional-p)
-            (cljr--point-in-reader-conditional-branch-p :clj)
-          (string-equal (cljr--prompt-user-for "Language context at point? "
-                                               (list "clj" "cljs"))
-                        "clj")))))
+        (cond
+          ((cljr--point-in-reader-conditional-p)
+           (cljr--point-in-reader-conditional-branch-p :clj))
+          (cljr-assume-language-context
+           (string-equal cljr-assume-language-context "clj"))
+          (t
+           (string-equal (cljr--prompt-user-for "Language context at point? "
+                                                (list "clj" "cljs"))
+                         "clj"))))))
 
 (defun cljr--aget (map key)
   (cdr (assoc key map)))


### PR DESCRIPTION
When the user enters an apparent namespace like `somelib/`, and
the language context is ambiguous, clj-refactor creates a popup
asking the user to specify whether the context is "clj" or "cljs".
This change allows the user to specify a language context which
should be assumed, so that clj-refactor will choose that context
in ambiguous cases rather than creating a popup. Default behavior
is still to create the popup; this change only creates a variable
that lets the user override that behavior.
Tested fairly extensively at REPL; it didn't seem substantial
enough to warrant a new automated test (especially since I've
never worked with Cucumber).

Resolves #394 

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
** See above
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
** Note: it wasn't clear to me how to add it to the changelog, since the changelog is version-based, and this didn't seem to warrant a version bump. Happy to add it if this is clarified.
- [ ] You've updated the readme (if adding/changing user-visible functionality)
** README points to `https://github.com/clojure-emacs/clj-refactor.el/wiki#customization`, which just says how to pull up the set of available customizations (& this now comes up as part of that set).

Thanks!
