### PR TITLE
Introduce `cljr-building-ast-cache?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#415](https://github.com/clojure-emacs/clj-refactor.el/issues/415) Support for deps.edn - based projects
+- [#408](https://github.com/clojure-emacs/clj-refactor.el/pull/408) New `cljr-before-warming-ast-cache-hook`, `cljr-after-warming-ast-cache-hook` callbacks around AST warming.
 - [#394](https://github.com/clojure-emacs/clj-refactor.el/issues/394) New config option `cljr-assume-language-context`: by default, when clj-refactor encounters an ambiguous context (clj vs cljs) it creates a popup asking user which context is meant. If this option is changed to "clj" or "cljs", clj-refactor will use that as the assumed context in such ambigous cases.
 - [#391](https://github.com/clojure-emacs/clj-refactor.el/issues/391) Prevent refactor-nrepl from being injected when starting a REPL outside a project, and add an option `cljr-suppress-outside-project-warning` to suppress the resultant warning.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -276,6 +276,16 @@ if it appears to be unused."
 (defvar cljr--find-symbol-buffer "*cljr-find-usages*")
 (defvar cljr--post-command-messages nil "Message(s) to display after the current command is done.")
 
+(defcustom cljr-before-warming-ast-cache-hook nil
+  "Runs before each time the AST is loaded."
+  :group 'cljr
+  :type 'function)
+
+(defcustom cljr-after-warming-ast-cache-hook nil
+  "Runs after each time the AST is loaded."
+  :group 'cljr
+  :type 'function)
+
 ;;; Buffer Local Declarations
 
 ;; tracking state of find-symbol buffer
@@ -2670,9 +2680,13 @@ Also adds the alias prefix to all occurrences of public symbols in the namespace
                             asts-in-bad-state) "; "))))))
 
 (defun cljr--warm-ast-cache ()
+  (when cljr-before-warming-ast-cache-hook
+    (funcall cljr-before-warming-ast-cache-hook))
   (cljr--call-middleware-async
    (cljr--create-msg "warm-ast-cache")
    (lambda (res)
+     (when cljr-after-warming-ast-cache-hook
+       (funcall cljr-after-warming-ast-cache-hook res))
      (cljr--maybe-rethrow-error res)
      (cljr--maybe-nses-in-bad-state res)
      (when cljr--debug-mode


### PR DESCRIPTION
Allows one to build helpers to reload code at the right time, avoiding https://github.com/clojure-emacs/refactor-nrepl/issues/134

As this is a simple variable, not sure if should go into changelog/readme?

Cheers - Victor