### PR TITLE
workaround (buffer-file-name) return nil issue

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1073,14 +1073,14 @@ word test in it and whether the file lives under the test/ directory."
     file-name))
 
 (defun cljr--ensure-no-dashes-in-filename ()
-  (unless (not (buffer-file-name))
-    (when (and (not (file-exists-p (buffer-file-name))) ; only new files
-               (cljr--dash-in-file-name-p (buffer-file-name)))
-      (let ((new-name (cljr--maybe-replace-dash-in-file-name (buffer-file-name))))
-        (rename-buffer new-name)
-        (set-visited-file-name new-name)
-        (message "Changed file name to '%s'"
-                 (file-name-nondirectory new-name))))))
+  (when (and (buffer-file-name)
+             (not (file-exists-p (buffer-file-name))) ; only new files
+             (cljr--dash-in-file-name-p (buffer-file-name)))
+    (let ((new-name (cljr--maybe-replace-dash-in-file-name (buffer-file-name))))
+      (rename-buffer new-name)
+      (set-visited-file-name new-name)
+      (message "Changed file name to '%s'"
+               (file-name-nondirectory new-name)))))
 
 (add-hook 'find-file-hook 'cljr--ensure-no-dashes-in-filename)
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1073,13 +1073,14 @@ word test in it and whether the file lives under the test/ directory."
     file-name))
 
 (defun cljr--ensure-no-dashes-in-filename ()
-  (when (and (not (file-exists-p (buffer-file-name))) ; only new files
-             (cljr--dash-in-file-name-p (buffer-file-name)))
-    (let ((new-name (cljr--maybe-replace-dash-in-file-name (buffer-file-name))))
-      (rename-buffer new-name)
-      (set-visited-file-name new-name)
-      (message "Changed file name to '%s'"
-               (file-name-nondirectory new-name)))))
+  (unless (not (buffer-file-name))
+    (when (and (not (file-exists-p (buffer-file-name))) ; only new files
+               (cljr--dash-in-file-name-p (buffer-file-name)))
+      (let ((new-name (cljr--maybe-replace-dash-in-file-name (buffer-file-name))))
+        (rename-buffer new-name)
+        (set-visited-file-name new-name)
+        (message "Changed file name to '%s'"
+                 (file-name-nondirectory new-name))))))
 
 (add-hook 'find-file-hook 'cljr--ensure-no-dashes-in-filename)
 


### PR DESCRIPTION
[Fix #388]

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
