### PR TITLE
Fix renamed cider function in resolve missing

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2847,7 +2847,7 @@ Date. -> Date
   ;; Just so this part can be mocked out in a step definition
   (when-let (candidates (thread-first (cljr--create-msg "resolve-missing"
                                                         "symbol" symbol
-                                                        "session" (cider-current-session))
+                                                        "session" (cider-nrepl-eval-session))
                           (cljr--call-middleware-sync
                            "candidates")))
     (edn-read candidates)))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2486,7 +2486,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-promote-function
                             "name" symbol
                             "ignore-errors"
                             (when (or cljr-find-usages-ignore-analyzer-errors cljr-ignore-analyzer-errors) "true"))))
-    (with-current-buffer (cider-current-repl-buffer)
+    (with-current-buffer (cider-current-repl)
       (setq cjr--occurrence-count 0)
       (setq cljr--num-syms -1)
       (setq cljr--occurrence-ids '()))


### PR DESCRIPTION
This PR should update a function name that was updated in cider recently in this commit https://github.com/clojure-emacs/cider/commit/5cb98a74bad81a2cd15f8db86c469020ed030156