### PR TITLE
[Fix #426] Expose variable to ignore paths in the middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ before_install:
   - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
 script:
   ./run-travis-ci.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Dropped support for emacs < 25.1 (to match CIDER).
 - [#426](https://github.com/clojure-emacs/clj-refactor.el/issues/426) New variable, `cljr-middleware-ignored-paths`, to make the middleware ignore certain paths.
 - [#408](https://github.com/clojure-emacs/clj-refactor.el/pull/408) New `cljr-before-warming-ast-cache-hook`, `cljr-after-warming-ast-cache-hook` callbacks around AST warming.
 - [#394](https://github.com/clojure-emacs/clj-refactor.el/issues/394) New config option `cljr-assume-language-context`: by default, when clj-refactor encounters an ambiguous context (clj vs cljs) it creates a popup asking user which context is meant. If this option is changed to "clj" or "cljs", clj-refactor will use that as the assumed context in such ambigous cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [#415](https://github.com/clojure-emacs/clj-refactor.el/issues/415) Support for deps.edn - based projects
+- [#426](https://github.com/clojure-emacs/clj-refactor.el/issues/426) New variable, `cljr-middleware-ignored-paths`, to make the middleware ignore certain paths.
 - [#408](https://github.com/clojure-emacs/clj-refactor.el/pull/408) New `cljr-before-warming-ast-cache-hook`, `cljr-after-warming-ast-cache-hook` callbacks around AST warming.
 - [#394](https://github.com/clojure-emacs/clj-refactor.el/issues/394) New config option `cljr-assume-language-context`: by default, when clj-refactor encounters an ambiguous context (clj vs cljs) it creates a popup asking user which context is meant. If this option is changed to "clj" or "cljs", clj-refactor will use that as the assumed context in such ambigous cases.
 - [#391](https://github.com/clojure-emacs/clj-refactor.el/issues/391) Prevent refactor-nrepl from being injected when starting a REPL outside a project, and add an option `cljr-suppress-outside-project-warning` to suppress the resultant warning.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -286,6 +286,12 @@ if it appears to be unused."
   :group 'cljr
   :type 'hook)
 
+(defcustom cljr-middleware-ignored-paths nil
+  "List of (Java style) regexes to paths that should be ignored
+  by the middleware."
+  :group 'cljr
+  :type '(repeat string))
+
 ;;; Buffer Local Declarations
 
 ;; tracking state of find-symbol buffer
@@ -2484,6 +2490,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-promote-function
                             "line" line
                             "column" column
                             "name" symbol
+                            "ignore-paths" cljr-middleware-ignored-paths
                             "ignore-errors"
                             (when (or cljr-find-usages-ignore-analyzer-errors cljr-ignore-analyzer-errors) "true"))))
     (with-current-buffer (cider-current-repl-buffer)


### PR DESCRIPTION
This makes it possible to easily exclude certain files and directories
for analysis.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

The code for this already exists in the middleware.  Not sure why a setting was never created.  Perhaps we just forgot?
