### PR TITLE
clean-ns: send both the absolute and relative path to the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#380](https://github.com/clojure-emacs/clj-refactor.el/issues/380) clean-ns: fix FileNotFoundException, by trying both the absolute path and the path relative to the project root. This requires a new refactor-nrepl, old versions will only check the absolute path.
+
 ## 2.4.0 (2018-08-26)
 
 - Compatible with CIDER 0.17 and 0.18.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2732,10 +2732,12 @@ removed."
   (unless (and *cljr--noninteractive*
                (not (buffer-modified-p)))
     (save-buffer))
-  (let ((path (or path (cljr--project-relative-path (buffer-file-name)))))
+  (let ((path (or path (buffer-file-name)))
+        (relative-path (cljr--project-relative-path path)))
     (when-let (new-ns (cljr--call-middleware-sync
                        (cljr--create-msg "clean-ns"
                                          "path" path
+                                         "relative-path" relative-path
                                          "libspec-whitelist" cljr-libspec-whitelist
                                          "prune-ns-form" (if no-prune? "false"
                                                            "true"))


### PR DESCRIPTION
This makes use of a change to refactor-nrepl [1], but should be safe when
using older versions of refactor-nrepl, as in that case it simply uses the
absolute path, which is generally preferred over the relative one.

When used with the change to refactor-nrepl it will try first the absolute, then
the relative path, and use the first that can be found.

[1]: https://github.com/clojure-emacs/refactor-nrepl/pull/251

Closes #380 
