### PR TITLE
Implement `cljr-magic-use-namespaces`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [#450](https://github.com/clojure-emacs/clj-refactor.el/pull/450) New config options: `cljr-magic-uses` (boolean) and `cljr-magic-uses-namespaces` (list): if boolean is `true`, upon creation of new namespace, add `:refer :all` entries for all namespaces in the list to the new namespace
+- [#450](https://github.com/clojure-emacs/clj-refactor.el/pull/450) New config option: `cljr-magic-uses-namespaces` (list): if list is non-empty, upon creation of new namespace, add `:refer :all` entries for all namespaces in the list to the new namespace
 - [#402](https://github.com/clojure-emacs/clj-refactor.el/issues/402) cljr-stop-referring: do not alter strings.
 - [#380](https://github.com/clojure-emacs/clj-refactor.el/issues/380) clean-ns: fix FileNotFoundException, by trying both the absolute path and the path relative to the project root. This requires a new refactor-nrepl, old versions will only check the absolute path.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#450](https://github.com/clojure-emacs/clj-refactor.el/pull/450) New config options: `cljr-magic-uses` (boolean) and `cljr-magic-uses-namespaces` (list): if boolean is `true`, upon creation of new namespace, add `:refer :all` entries for all namespaces in the list to the new namespace
 - [#402](https://github.com/clojure-emacs/clj-refactor.el/issues/402) cljr-stop-referring: do not alter strings.
 - [#380](https://github.com/clojure-emacs/clj-refactor.el/issues/380) clean-ns: fix FileNotFoundException, by trying both the absolute path and the path relative to the project root. This requires a new refactor-nrepl, old versions will only check the absolute path.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -82,16 +82,10 @@ Any other non-nil value means to add the form without asking."
                        (string :tag "Full namespace")))
   :group 'cljr)
 
-(defcustom cljr-magic-uses nil
-  "Whether to automatically use namespaces specified by
-`cljr-magic-use-namespaces' upon namespace creation."
-  :group 'cljr
-  :type '(choice (const :tag "true" t)
-                 (const :tag "false" nil)))
-
 (defcustom cljr-magic-use-namespaces
   '()
-  "List of namespaces used by `cljr-magic-uses'."
+  "List of namespaces for whose entries are referred upon
+creation of a new namespace."
   :type '(repeat (string :tag "Full namespace"))
   :group 'cljr)
 
@@ -1117,7 +1111,7 @@ word test in it and whether the file lives under the test/ directory."
                (cljr--clojure-ish-filename-p (buffer-file-name))
                (= (point-min) (point-max)))
       (insert (format "(ns %s)\n\n" (cider-expected-ns)))
-      (when cljr-magic-uses
+      (when (not (null cljr-magic-use-namespaces))
         (cljr--add-magic-uses))
       (when (cljr--in-tests-p)
         (cljr--add-test-declarations)))))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -82,6 +82,19 @@ Any other non-nil value means to add the form without asking."
                        (string :tag "Full namespace")))
   :group 'cljr)
 
+(defcustom cljr-magic-uses nil
+  "Whether to automatically use namespaces specified by
+`cljr-magic-use-namespaces' upon namespace creation."
+  :group 'cljr
+  :type '(choice (const :tag "true" t)
+                 (const :tag "false" nil)))
+
+(defcustom cljr-magic-use-namespaces
+  '()
+  "List of namespaces used by `cljr-magic-uses'."
+  :type '(repeat (string :tag "Full namespace"))
+  :group 'cljr)
+
 (defcustom cljr-project-clean-prompt t
   "If t, `cljr-project-clean' asks before doing anything.
 If nil, the project clean functions are run without warning."
@@ -1053,6 +1066,12 @@ If CLJS? is T we insert in the cljs part of the ns declaration."
       (string-equal (file-name-extension (buffer-file-name (or buf (current-buffer))))
                     "clj")))
 
+(defun cljr--add-magic-uses ()
+  (save-excursion
+    (dolist (namespace cljr-magic-use-namespaces)
+      (cljr--insert-in-ns ":require")
+      (insert "[" namespace " :refer :all]"))))
+
 (defun cljr--add-test-declarations ()
   (save-excursion
     (let* ((ns (clojure-find-ns))
@@ -1098,6 +1117,8 @@ word test in it and whether the file lives under the test/ directory."
                (cljr--clojure-ish-filename-p (buffer-file-name))
                (= (point-min) (point-max)))
       (insert (format "(ns %s)\n\n" (cider-expected-ns)))
+      (when cljr-magic-uses
+        (cljr--add-magic-uses))
       (when (cljr--in-tests-p)
         (cljr--add-test-declarations)))))
 

--- a/features/magic-uses.feature
+++ b/features/magic-uses.feature
@@ -2,7 +2,6 @@ Feature: Magic uses
 
   Background:
     Given I have a project "cljr" in "tmp"
-    And I enable cljr-magic-uses
     And I add "my.prelude" to cljr-magic-use-namespaces
     And I add "my.http-client" to cljr-magic-use-namespaces
     When I have a clojure-file "tmp/src/cljr/core.clj"

--- a/features/magic-uses.feature
+++ b/features/magic-uses.feature
@@ -1,0 +1,17 @@
+Feature: Magic uses
+
+  Background:
+    Given I have a project "cljr" in "tmp"
+    And I enable cljr-magic-uses
+    And I add "my.prelude" to cljr-magic-use-namespaces
+    And I add "my.http-client" to cljr-magic-use-namespaces
+    When I have a clojure-file "tmp/src/cljr/core.clj"
+
+  Scenario: Referrals are inserted automagically
+    When I open file "tmp/src/cljr/core.clj"
+    Then I should see:
+    """
+    (ns cljr.core
+      (:require [my.http-client :refer :all]
+                [my.prelude :refer :all]))
+    """

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -64,6 +64,14 @@
        (lambda ()
          (setq cljr-use-multiple-cursors nil)))
 
+(Given "^I enable cljr-magic-uses"
+       (lambda ()
+         (setq cljr-magic-uses t)))
+
+(Given "^I add \"\\([^\"]+\\)\" to cljr-magic-use-namespaces$"
+       (lambda (namespace)
+         (add-to-list 'cljr-magic-use-namespaces namespace)))
+
 (defun cljr--plist-to-hash (plist)
   (let ((h (make-hash-table)))
     (dolist (k (-filter #'keywordp plist))

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -64,10 +64,6 @@
        (lambda ()
          (setq cljr-use-multiple-cursors nil)))
 
-(Given "^I enable cljr-magic-uses"
-       (lambda ()
-         (setq cljr-magic-uses t)))
-
 (Given "^I add \"\\([^\"]+\\)\" to cljr-magic-use-namespaces$"
        (lambda (namespace)
          (add-to-list 'cljr-magic-use-namespaces namespace)))


### PR DESCRIPTION
This feature is similar to `cljr-magic-require-namespaces` but instead
of creating aliases, it refers all symbols from the namespace.

I have a hunch that this would be better if it just exposed the list option and triggered the logic when the list is non-empty. [Any thoughts?](https://github.com/clojure-emacs/clj-refactor.el/pull/450/commits/6e8f829f2a420f0a5586fb4f59026f1cf7562d42)

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!