### PR TITLE
Update cider dependency and GNU ELPA gpg keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > evm-travis.sh && source ./evm-travis.sh
   - evm install $EVM_EMACS --use --skip
+  - mkdir -p .emacs.d/elpa/gnupg && chmod 700 .emacs.d/elpa/gnupg
+  - gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir .emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+  - mkdir -p $(cask package-directory) && cp -pr .emacs.d/elpa/gnupg $(cask package-directory)
   - cask
 env:
   - EVM_EMACS=emacs-25.1-travis

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -8,7 +8,7 @@
 ;;         Benedek Fazekas <benedek.fazekas@gmail.com>
 ;; Version: 2.5.0-snapshot
 ;; Keywords: convenience, clojure, cider
-;; Package-Requires: ((emacs "25.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.6.1") (cider "0.17.0") (edn "1.1.2") (inflections "2.3") (hydra "0.13.2"))
+;; Package-Requires: ((emacs "25.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.6.1") (cider "0.23.0") (edn "1.1.2") (inflections "2.3") (hydra "0.13.2"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License


### PR DESCRIPTION
The problem of failing builds is mainly caused by expired elpa gpg keys. I also updated cider dependency, although I'm neither sure we need to do that, nor I don't really know what version should we depend on? snapshot? :)

