### PR TITLE
Fix require to use parseedn feature instead of edn feature

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -44,7 +44,7 @@
 (require 'multiple-cursors-core)
 (require 'clojure-mode)
 (require 'cider)
-(require 'edn)
+(require 'parseedn)
 (require 'sgml-mode)
 (require 'inflections)
 (require 'hydra)


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [N/A] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [N/A] You've added tests (if possible) to cover your change(s)
- [X] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [N/A] You've updated the changelog (if adding/changing user-visible functionality)
- [N/A] You've updated the readme (if adding/changing user-visible functionality)

This fixes an error with loading clj-refactor.el on installs that don't already have the `edn` package available. The `edn` package is no longer required by clj-refactor.el (being replaced by `parseedn`), but still makes the incorrect require call.

The only test which isn't passing, also wasn't passing before the change, it being the circular-dependency check.

Fixes #462 