### PR TITLE
Fix breakage introduced by commit 24ea02bad in clojure-mode

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -959,7 +959,7 @@ Please, install (or update) refactor-nrepl %s and restart the REPL."
 (defun cljr--goto-ns ()
   "Go to the first namespace defining form in the buffer."
   (goto-char (point-min))
-  (if (re-search-forward clojure-namespace-name-regex nil t)
+  (if (re-search-forward clojure-namespace-regexp nil t)
       (cljr--goto-toplevel)
     (error "No namespace declaration found")))
 
@@ -970,10 +970,10 @@ no namespace form above point, return the first one in the buffer."
   (save-restriction
     (widen)
     ;; The closest ns form above point.
-    (when (or (re-search-backward clojure-namespace-name-regex nil t)
+    (when (or (re-search-backward clojure-namespace-regexp nil t)
               ;; Or any form at all.
               (and (goto-char (point-min))
-                   (re-search-forward clojure-namespace-name-regex nil t)))
+                   (re-search-forward clojure-namespace-regexp nil t)))
       (cljr--goto-toplevel))))
 
 (defun cljr--goto-cljs-branch ()


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [X] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

##  Expected behavior

TravisCI builds run successfully.

## Actual behavior

TravisCI builds fail with:

```
In toplevel form:

clj-refactor.el:962:26:Error: ‘clojure-namespace-name-regex’ is an obsolete variable (as of 5.12.0); use ‘clojure-namespace-regexp’ instead.

The command "./run-travis-ci.sh" exited with 1.
```

## Steps to reproduce the problem

Push new commits to master or rebuild any job for commits done after March 20, 2020 (the day commit 24ea02bad was added to clojure-mode)

## Environment & Version information

### clj-refactor.el version information

Latest master commit

### CIDER version information

The version specified in TravisCI build configuration.

### Leiningen or Boot version

The version specified in TravisCI build configuration.

### Emacs version

The version specified in TravisCI build configuration.

### Operating system

The version specified in TravisCI build configuration.
