### PR TITLE
WIP: Fix cljr-magic-requires :prompt

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1980,7 +1980,7 @@ form."
         (when-let (long (cljr--prompt-user-for "Require " (cl-second aliases)))
           (when (and (not (cljr--in-namespace-declaration-p (concat ":as " short "\b")))
                      (or (not (eq :prompt cljr-magic-requires))
-                         (not (> (length (cl-second aliases)) 1)) ; already prompted
+                         (> (length (cl-second aliases)) 1) ; already prompted
                          (yes-or-no-p (format "Add %s :as %s to requires?" long short))))
             (save-excursion
               (cljr--insert-in-ns ":require")


### PR DESCRIPTION
WIP: tests/changelog to be done

Fix `cljr-magic-requires` when it equals to `:prompt`:

If `(> (length (cl-second aliases)) 1)` is true, then the user was already prompted by `(cljr--prompt-user-for "Require " (cl-second aliases))`, in which case we want it to evaluate to `true` to short-circuit the `or`.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
