### PR TITLE
Automatically namespace artifacts in deps.edn

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2250,7 +2250,11 @@ possible choices. If the choice is trivial, return it."
   (forward-sexp)
   (backward-char)
   (newline-and-indent)
-  (insert artifact " {:mvn/version \"" version "\"}"))
+  (let ((artifact (if (string-match-p "^.+/.+$" artifact)
+                      artifact
+                    (format "%s/%s" artifact artifact))))
+    (insert artifact " {:mvn/version \"" version "\"}")))
+
 
 (defun cljr--add-project-dependency (artifact version)
   (let* ((project-file (cljr--project-file))

--- a/features/add-or-update-dependency-in-clj-project.feature
+++ b/features/add-or-update-dependency-in-clj-project.feature
@@ -13,6 +13,15 @@ Feature: Add or update dependency in clj project
             org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}}}
     """
 
+  Scenario: New dependency without namespace is added
+    When I add dependency artifact "hiccup" with version "2.0.0-alpha2"
+    Then I should see:
+    """
+    {:paths ["src" "resources"]
+     :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+            hiccup/hiccup {:mvn/version "2.0.0-alpha2"}}}
+    """
+
   Scenario: Existing dependency is updated
     When I locate dependency artifact "org.clojure/clojure"
     And I update artifact version to "1.9.1"


### PR DESCRIPTION
As un-namespaced artifacts are now deprecated.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [n/a] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [no, see Scenario: Move forms does not create circular dependencies, #341] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
