### PR TITLE
Adjust to breaking changes in CIDER

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2523,7 +2523,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-promote-function
                             "ignore-paths" cljr-middleware-ignored-paths
                             "ignore-errors"
                             (when cljr-ignore-analyzer-errors "true"))))
-    (with-current-buffer (with-no-warnings (cider-current-repl-buffer))
+    (with-current-buffer (with-no-warnings (cider-current-repl))
       (setq cjr--occurrence-count 0)
       (setq cljr--num-syms -1)
       (setq cljr--occurrence-ids '()))
@@ -2885,7 +2885,7 @@ Date. -> Date
   (when-let (candidates (thread-first (cljr--create-msg "resolve-missing"
                                                         "symbol" symbol
                                                         "session"
-                                                        (with-no-warnings (cider-current-session)))
+                                                        (with-no-warnings (cider-nrepl-eval-session)))
                           (cljr--call-middleware-sync
                            "candidates")))
     (parseedn-read-str candidates)))


### PR DESCRIPTION
Happy new year.

It saddens me deeply that we as a community have not yet moved past this unnecessary churn.

For reference, I generated these based on the now deleted aliases in CIDER (relies on zsh-style globs and GNU sed)

```
sed 's/cider-connect-clojurescript/cider-connect-cljs/g' -i **/*(.)
sed 's/cider-connect-clojure/cider-connect-clj/g' -i **/*(.)
sed 's/cider-connect-sibling-clojurescript/cider-connect-sibling-cljs/g' -i **/*(.)
sed 's/cider-connect-sibling-clojure/cider-connect-sibling-clj/g' -i **/*(.)
sed 's/cider-current-repl-buffer/cider-current-repl/g' -i **/*(.)
sed 's/cider-current-session/cider-nrepl-eval-session/g' -i **/*(.)
sed 's/cider-current-tooling-session/cider-nrepl-tooling-session/g' -i **/*(.)
sed 's/cider-default-repl-command/cider-jack-in-default/g' -i **/*(.)
sed 's/cider-display-connection-info/cider-describe-connection/g' -i **/*(.)
sed 's/cider-jack-in-clojurescript/cider-jack-in-cljs/g' -i **/*(.)
sed 's/cider-jack-in-clojure/cider-jack-in-clj/g' -i **/*(.)
sed 's/cider-refresh-after-fn/cider-ns-refresh-after-fn/g' -i **/*(.)
sed 's/cider-refresh-before-fn/cider-ns-refresh-before-fn/g' -i **/*(.)
sed 's/cider-refresh-show-log-buffer/cider-ns-refresh-show-log-buffer/g' -i **/*(.)
sed 's/cider-refresh/cider-ns-refresh/g' -i **/*(.)
sed 's/cider-repl-buffers/cider-repls/g' -i **/*(.)
sed 's/cider-repl-set-type/cider-set-repl-type/g' -i **/*(.)
sed 's/cider-save-files-on-cider-ns-refresh/cider-ns-save-files-on-refresh/g' -i **/*(.)
sed 's/cider-switch-to-repl-after-insert-p/cider-switch-to-repl-on-insert/g' -i **/*(.)
sed 's/nrepl-connection-buffer-name/nrepl-repl-buffer-name/g' -i **/*(.)
```
