### PR TITLE
Fix clojure-cli warning about unqualified dependencies

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -4125,7 +4125,7 @@ If injecting the dependencies is not preferred set `cljr-inject-dependencies-at-
   (when (and cljr-inject-dependencies-at-jack-in
              (boundp 'cider-jack-in-lein-plugins)
              (boundp 'cider-jack-in-nrepl-middlewares))
-    (add-to-list 'cider-jack-in-lein-plugins `("refactor-nrepl" ,(cljr--version t)
+    (add-to-list 'cider-jack-in-lein-plugins `("refactor-nrepl/refactor-nrepl" ,(cljr--version t)
                                                :predicate cljr--inject-middleware-p))
     (add-to-list 'cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor"
                                                     :predicate cljr--inject-middleware-p))))


### PR DESCRIPTION
Without this running `cider-jack-in` in a clojure project
with clojure-cli will produce warnings about unqualified
dependencies which may cause errors in future releases.

This PR makes sure that all injected dependencies are
qualified.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [-] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [-] All tests are passing (run `./run-tests.sh`) -> one test is failing but this is also happening on master and is most likely be caused by my system.
- [-] You've updated the changelog (if adding/changing user-visible functionality) -> Functionality is not user-visible
- [-] You've updated the readme (if adding/changing user-visible functionality) -> Functionality is not user-visible