### PR TITLE
Add a step to upgrade cask

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ default: &default-steps
   steps:
     - checkout
     - run: apt-get update && apt-get install make
+    - run: cask upgrade-cask || true
     - run: make elpa
     - run: emacs --version
     - run: cask --version
@@ -16,12 +17,11 @@ default: &default-steps
 
 # Enumerated list of Emacs versions
 jobs:
-  # TODO: Figure out why the queue fails to install on Emacs 25
-  # test-emacs-25:
-  #   docker:
-  #     - image: silex/emacs:25-ci-cask
-  #       entrypoint: bash
-  #   <<: *default-steps
+  test-emacs-25:
+    docker:
+      - image: silex/emacs:25-ci-cask
+        entrypoint: bash
+    <<: *default-steps
 
   test-emacs-26:
     docker:
@@ -45,7 +45,7 @@ workflows:
   version: 2
   ci-test-matrix:
     jobs:
-      # - test-emacs-25
+      - test-emacs-25
       - test-emacs-26
       - test-emacs-27
       - test-emacs-master


### PR DESCRIPTION
This is a (potential) fix for the tests failing against Emacs 25. I
used this config file as a template to create the config file for
vedang/pdf-tools@6ddfda8b and faced the same problem. The failure was
in Cask not being able to install `cl-lib`, which seemed strange to
me. I guessed that the emacs-25 image might not have been baked
properly.

Adding this step fixed the problem for my repository.