### PR TITLE
Make cljr-slash a no-op on fractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#483](https://github.com/clojure-emacs/clj-refactor.el/issues/483): Improve performance of cljr-slash when typing fraction literals.
 - [#482](https://github.com/clojure-emacs/clj-refactor.el/issues/482): Add missing defgroup form.
 - [#470](https://github.com/clojure-emacs/clj-refactor.el/issues/470): Choose `deps.edn` over `pom.xml` as project file.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1968,6 +1968,11 @@ the alias in the project."
     (clojure-backward-logical-sexp 1)
     (looking-at-p "#")))
 
+(defun cljr--in-number-p ()
+  (save-excursion
+    (backward-sexp 1)
+    (looking-at-p "[-+0-9]")))
+
 ;;;###autoload
 (defun cljr-slash ()
   "Inserts / as normal, but also checks for common namespace shorthands to require.
@@ -1984,6 +1989,7 @@ form."
                           (not (cider-in-comment-p))
                           (not (cider-in-string-p))
                           (not (cljr--in-keyword-sans-alias-p))
+                          (not (cljr--in-number-p))
                           (clojure-find-ns)
                           (cljr--magic-requires-lookup-alias)))
     (let ((short (cl-first aliases)))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -69,7 +69,8 @@
 
 (defcustom cljr-magic-requires t
   "Whether to automatically require common namespaces when they are used.
-These are the namespaces listed in `cljr-magic-require-namespaces'.
+These are the namespaces listed in `cljr-magic-require-namespaces'
+and returned by the `namespace-aliases' middleware op.
 
 If this variable is `:prompt', typing the short form followed by
 `\\[cljr-slash]' will ask if you want to add the corresponding require
@@ -1976,10 +1977,9 @@ the alias in the project."
 ;;;###autoload
 (defun cljr-slash ()
   "Inserts / as normal, but also checks for common namespace shorthands to require.
-If `cljr-magic-require-namespaces' is non-nil, typing one of the
-short aliases listed in `cljr-magic-requires' followed by this
-command will add the corresponding require statement to the ns
-form."
+If `cljr-magic-requires' is non-nil, executing this command after one of the aliases
+listed in `cljr-magic-require-namespaces', or any alias used elsewhere in the project,
+will add the corresponding require statement to the ns form."
   (interactive)
   (insert "/")
   (when-let (aliases (and cljr-magic-requires

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1977,28 +1977,28 @@ command will add the corresponding require statement to the ns
 form."
   (interactive)
   (insert "/")
-  (unless (or (cljr--in-map-destructuring?)
-              (cljr--in-ns-above-point-p)
-              (cljr--in-reader-literal-p))
-    (when-let (aliases (and cljr-magic-requires
-                            (not (cider-in-comment-p))
-                            (not (cider-in-string-p))
-                            (not (cljr--in-keyword-sans-alias-p))
-                            (clojure-find-ns)
-                            (cljr--magic-requires-lookup-alias)))
-      (let ((short (cl-first aliases)))
-        (when-let (long (cljr--prompt-user-for "Require " (cl-second aliases)))
-          (when (and (not (cljr--in-namespace-declaration-p (concat ":as " short "\b")))
-                     (or (not (eq :prompt cljr-magic-requires))
-                         (not (> (length (cl-second aliases)) 1)) ; already prompted
-                         (yes-or-no-p (format "Add %s :as %s to requires?" long short))))
-            (save-excursion
-              (cljr--insert-in-ns ":require")
-              (let ((libspec (format "[%s :as %s]" long short)))
-                (insert libspec)
-                (ignore-errors (cljr--maybe-eval-ns-form))
-                (cljr--indent-defun)
-                (cljr--post-command-message "Required %s" libspec)))))))))
+  (when-let (aliases (and cljr-magic-requires
+                          (not (cljr--in-map-destructuring?))
+                          (not (cljr--in-ns-above-point-p))
+                          (not (cljr--in-reader-literal-p))
+                          (not (cider-in-comment-p))
+                          (not (cider-in-string-p))
+                          (not (cljr--in-keyword-sans-alias-p))
+                          (clojure-find-ns)
+                          (cljr--magic-requires-lookup-alias)))
+    (let ((short (cl-first aliases)))
+      (when-let (long (cljr--prompt-user-for "Require " (cl-second aliases)))
+        (when (and (not (cljr--in-namespace-declaration-p (concat ":as " short "\b")))
+                   (or (not (eq :prompt cljr-magic-requires))
+                       (not (> (length (cl-second aliases)) 1)) ; already prompted
+                       (yes-or-no-p (format "Add %s :as %s to requires?" long short))))
+          (save-excursion
+            (cljr--insert-in-ns ":require")
+            (let ((libspec (format "[%s :as %s]" long short)))
+              (insert libspec)
+              (ignore-errors (cljr--maybe-eval-ns-form))
+              (cljr--indent-defun)
+              (cljr--post-command-message "Required %s" libspec))))))))
 
 (defun cljr--in-namespace-declaration-p (s)
   (save-excursion


### PR DESCRIPTION
This prevents the expensive alias lookup when typing the slash in fraction literals eg. `1/2`.
Also updates the docstring, fixes #481.

There is one unrelated failing test involving to cljr-move-form, which also fails on the master branch.

----
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
