### PR TITLE
Introduce `cljr-insert-newline-after-require` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#483](https://github.com/clojure-emacs/clj-refactor.el/issues/483): Improve performance of cljr-slash when typing fraction literals.
 - [#482](https://github.com/clojure-emacs/clj-refactor.el/issues/482): Add missing defgroup form.
 - [#470](https://github.com/clojure-emacs/clj-refactor.el/issues/470): Choose `deps.edn` over `pom.xml` as project file.
+- Introduce `defcustom cljr-insert-newline-after-require` option.
 
 ## 2.5.1 (2021-02-16)
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -126,6 +126,11 @@ This only applies to dependencies added by `cljr-add-project-dependency'."
   :group 'cljr
   :type 'boolean)
 
+(defcustom cljr-insert-newline-after-require t
+  "If t, `cljr-clean-ns' will place a newline after the `:require` and `:import` tokens."
+  :group 'cljr
+  :type 'boolean)
+
 (defcustom cljr-use-multiple-cursors t
   "If t, some refactorings use the `multiple-cursors' package.
 This improves interactivity of the commands.  If nil, those
@@ -749,6 +754,10 @@ All config settings are included in the created msg."
   (apply #'list "op" op
          "prefix-rewriting"
          (if cljr-favor-prefix-notation
+             "true"
+           "false")
+         "insert-newline-after-require"
+         (if cljr-insert-newline-after-require
              "true"
            "false")
          "debug"


### PR DESCRIPTION
Context: https://github.com/clojure-emacs/refactor-nrepl/pull/303

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
