### PR TITLE
Partially revert "[Fix #496] Drop support for Emacs 25"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - [#470](https://github.com/clojure-emacs/clj-refactor.el/issues/470): Choose `deps.edn` over `pom.xml` as project file.
 - Introduce `defcustom cljr-insert-newline-after-require` option.
 - Introduce `defcustom cljr-injected-middleware-version` option, allowing users to customize the [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) version to be used.
-- Dropped support for Emacs 25 (to match CIDER).
 
 ## 2.5.1 (2021-02-16)
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -10,7 +10,7 @@
 ;; Version: 2.5.1
 ;; Keywords: convenience, clojure, cider
 
-;; Package-Requires: ((emacs "26.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.9") (cider "1.0") (parseedn "1.0.4") (inflections "2.3") (hydra "0.13.2"))
+;; Package-Requires: ((emacs "25.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.9") (cider "1.0") (parseedn "0.2") (inflections "2.3") (hydra "0.13.2"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -31,7 +31,12 @@
 
 ;;; Code:
 
+;; HACK: In Emacs 25.1, an older version of seq.el is provided, which can be
+;; loaded before jade or even package.el.  If this happens, the feature `seq'
+;; being already provided, the correct version of seq.el won't get loaded.
 (require 'seq)
+(unless (fboundp 'seq-map-indexed)
+  (require 'seq-25))
 
 (require 'clj-refactor-compat)
 (require 'yasnippet)


### PR DESCRIPTION
Partially reverts commit ecad41a5881111d620fe5735f95a28a003a7f8aa.

It seems fine to me to remove it from CI but I don't think we should drop compat if a presumably non-problematic hack can support it.

For one thing I happen to use 25 atm (I used 26 earlier but with Big Sur something changed). Sadly there are breaking changes across Emacs versions (25 -> 26 -> 27), some of them _very_ hard to track for non- Emacs insiders like me, so using an old Emacs isn't entirely out of the question.