### PR TITLE
Use the latest middleware

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -3249,7 +3249,7 @@ if REMOVE-PACKAGE_VERSION is t get rid of the (package: 20150828.1048) suffix."
         (replace-regexp-in-string " (.*)" "" version)
       version)))
 
-(defcustom cljr-injected-middleware-version (cljr--version t)
+(defcustom cljr-injected-middleware-version "3.0.0-alpha11" ;; (cljr--version t)
   "The refactor-nrepl version to be injected.
 
 You can customize this in order to try out new releases.


### PR DESCRIPTION
Proposes using the latest middleware (the 3.* series is much more stable, no breaking changes) for clj-refactor.el users using the latest snapshot.

This way we can get extra user testing.

After releasing the 3.0.0 middleware (no alpha), we can undo this change and also bump clj-refactor.el itself to 3.0.0.

See also https://github.com/clojure-emacs/refactor-nrepl/pull/337
