### PR TITLE
Prefer `find-file-noselect` to `with-temp-file`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#139](https://github.com/clojure-emacs/clj-refactor.el/issues/139): avoid a repeated prompt when using `(cljr-project-clean)`.
+
 ## 3.0.0 (2021-10-25)
 
 - [#483](https://github.com/clojure-emacs/clj-refactor.el/issues/483): Improve performance of `cljr-slash` when typing fraction literals.


### PR DESCRIPTION
`with-temp-file` causes `(buffer-file-name)` to return nil which is the root cause of #139.

Additionally, now `cljr--update-file` does not leave files open (unless they were alrady open), improving performance / UX.

Fixes https://github.com/clojure-emacs/clj-refactor.el/issues/139