### PR TITLE
Fix occasional `:require` / `:require-macros` confusion in `cljr-slash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#512](https://github.com/clojure-emacs/clj-refactor.el/issues/512): Fix occasional :require` / `:require-macros` confusion in `cljr-slash`.
+
 ## 3.3.3
 
 - Adapt `cljr--inject-jack-in-dependencies` to upstream changes in CIDER. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Use refactor-nrepl [3.4.0](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.4.0/CHANGELOG.md#340).
 - [#512](https://github.com/clojure-emacs/clj-refactor.el/issues/512): Fix occasional :require` / `:require-macros` confusion in `cljr-slash`.
 
 ## 3.3.3

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Either in your project's `project.clj` or in the `:user`
 profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "2.5.0"]
-          [cider/cider-nrepl "0.24.0"]]
+:plugins [[refactor-nrepl "3.4.0"]
+          [cider/cider-nrepl "0.28.3"]]
 ```
 
 Check out the much longer

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -7,7 +7,7 @@
 ;;         Lars Andersen <expez@expez.com>
 ;;         Benedek Fazekas <benedek.fazekas@gmail.com>
 ;;         Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 3.3.2
+;; Version: 3.4.0
 ;; Keywords: convenience, clojure, cider
 
 ;; Package-Requires: ((emacs "26.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.9") (cider "1.0") (parseedn "1.0.6") (inflections "2.3") (hydra "0.13.2"))
@@ -3284,7 +3284,7 @@ if REMOVE-PACKAGE_VERSION is t get rid of the (package: 20150828.1048) suffix."
 ;; We used to derive the version out of `(cljr--version t)`,
 ;; but now prefer a fixed version to fully decouple things and prevent unforeseen behavior.
 ;; This suits better our current pace of development.
-(defcustom cljr-injected-middleware-version "3.3.2"
+(defcustom cljr-injected-middleware-version "3.4.0"
   "The refactor-nrepl version to be injected.
 
 You can customize this in order to try out new releases.


### PR DESCRIPTION
* Fix occasional `:require` / `:require-macros` confusion in `cljr-slash`
  * Fixes https://github.com/clojure-emacs/clj-refactor.el/issues/512
* Use refactor-nrepl 3.4.0