### PR TITLE
Bump inflections to 2.6

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -10,7 +10,7 @@
 ;; Version: 3.5.2
 ;; Keywords: convenience, clojure, cider
 
-;; Package-Requires: ((emacs "26.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.14") (cider "1.3") (parseedn "1.0.6") (inflections "2.3") (hydra "0.13.2"))
+;; Package-Requires: ((emacs "26.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.14") (cider "1.3") (parseedn "1.0.6") (inflections "2.6") (hydra "0.13.2"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Bump inflections to 2.6 to incorporate this fix[1] for emacs 28

[1] https://github.com/eschulte/jump.el/pull/16

note: The below template seems to be out of date -- I installed cask and ran the command but got a warning about missing yasnippets. Also there is no ./run-tests.sh script, and `make unit-test` notes I'm missing `buttercup`

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
