### PR TITLE
Prompt user for new requires across language contexts using a single completing read

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1957,7 +1957,7 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
     (cljr--call-middleware-sync "namespace-aliases")
     parseedn-read-str))
 
-(defun cljr--namespace-aliases ()
+(defun cljr--get-aliases-from-middleware ()
   "Calculate a list of alias, namespace, lang-contexts from middleware."
   (when-let (aliases (cljr--call-middleware-for-namespace-aliases))
     (let ((alias-list ; list of all alias, require, lang-context
@@ -2041,7 +2041,7 @@ cljs) the alias has been used in previously."
                               (or (equal (intern short) (car elt))
                                   ;; but fallback on matching full namespace
                                   (equal short (symbol-name (cadr elt)))))
-                            (cljr--namespace-aliases))))
+                            (cljr--get-aliases-from-middleware))))
           candidates
         (when (and cljr-magic-require-namespaces ; a regex against "" always triggers
                    (string-match-p (cljr--magic-requires-re) short))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1999,14 +1999,18 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
   (and (cljr--cljs-file-p)
        (string-equal "js" alias)))
 
+(defun cljr--ns-short-alias-at-point ()
+  "Returns the (alias)/ just prior to the point excluding the trailing slash."
+  (thread-last (buffer-substring-no-properties
+                (cljr--point-after 'paredit-backward)
+                (1- (point)))
+               (string-remove-prefix "::")
+               (string-remove-prefix "@")))
+
 (defun cljr--magic-requires-lookup-alias ()
   "Return (alias (ns.candidate1 ns.candidate1)) if we recognize
 the alias in the project."
-  (let ((short (thread-last (buffer-substring-no-properties
-                             (cljr--point-after 'paredit-backward)
-                             (1- (point)))
-                 (string-remove-prefix "::")
-                 (string-remove-prefix "@"))))
+  (let ((short (cljr--ns-short-alias-at-point)))
     (unless (or (cljr--resolve-alias short)
                 (cljr--js-alias-p short))
       (if-let ((aliases (ignore-errors (cljr--get-aliases-from-middleware)))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1957,8 +1957,8 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
     (cljr--call-middleware-sync "namespace-aliases")
     parseedn-read-str))
 
-(defun cljr--aliases-from-middleware ()
-  "Calculate a list of alias, require, lang-contexts from middleware."
+(defun cljr--namespace-aliases ()
+  "Calculate a list of alias, namespace, lang-contexts from middleware."
   (when-let (aliases (cljr--call-middleware-for-namespace-aliases))
     (let ((alias-list ; list of all alias, require, lang-context
            (cl-loop for lang-context being the hash-keys of aliases
@@ -2041,7 +2041,7 @@ cljs) the alias has been used in previously."
                               (or (equal (intern short) (car elt))
                                   ;; but fallback on matching full namespace
                                   (equal short (symbol-name (cadr elt)))))
-                            (cljr--aliases-from-middleware))))
+                            (cljr--namespace-aliases))))
           candidates
         (when (and cljr-magic-require-namespaces ; a regex against "" always triggers
                    (string-match-p (cljr--magic-requires-re) short))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1988,8 +1988,8 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
                        (cl-loop for alias-require being the elements of alias-requires
                                 collect (list alias-name alias-require lang-context)))))))
 
-(defun cljr--namespace-completion (search-alias candidates)
-  "Complete best require for a given `search-alias`."
+(defun cljr--prompt-for-namespace (candidates)
+  "Prompt to select namespace from a list of candidate requires."
   (when candidates
     (let ((alias-index (make-hash-table :test 'equal)))
       (dolist (elt candidates)
@@ -2004,9 +2004,7 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
                              (symbol-name alias-name)))
                    (list alias-name alias-require)
                    alias-index)))
-      (let ((ns-require (completing-read "Require: "
-                                         alias-index
-                                         nil nil search-alias)))
+      (let ((ns-require (completing-read "Require: " alias-index)))
         (gethash ns-require alias-index)))))
 
 (defun cljr--js-alias-p (alias)
@@ -2084,7 +2082,7 @@ will add the corresponding require statement to the ns form."
                           (not (cljr--in-number-p))
                           (clojure-find-ns)
                           (cljr--magic-requires-lookup-alias)))
-    (when-let (selected-ns (cljr--namespace-completion (cljr--ns-short-alias-at-point) aliases))
+    (when-let (selected-ns (cljr--prompt-for-namespace aliases))
       (let ((short (symbol-name (cl-first selected-ns)))
             (long (cl-second selected-ns)))
         (when (and (not (cljr--in-namespace-declaration-p (concat ":as " short "\b")))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1963,6 +1963,24 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
         (gethash :clj aliases)
       (gethash :cljs aliases))))
 
+(defun cljr-aliases-from-middleware ()
+  "quick debug display of middleware output"
+  (interactive)
+  (let ((buf (cider-popup-buffer "*cider ns aliases*")))
+    (when-let (aliases (cljr--call-middleware-for-namespace-aliases))
+      (with-current-buffer buf
+        (setq buffer-read-only nil)
+        (cl-loop for alias-type being the hash-keys of aliases
+                 using (hash-values alias-values)
+                 do
+                 (insert (format "%S\n" alias-type))
+                 (cl-loop for short being the hash-keys of alias-values
+                          using (hash-values long)
+                          do
+                          (insert (format "%S\t%S\n" short long)))
+                 (insert "\n"))
+        (setq buffer-read-only t)))))
+
 (defun cljr--js-alias-p (alias)
   (and (cljr--cljs-file-p)
        (string-equal "js" alias)))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1957,12 +1957,6 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
     (cljr--call-middleware-sync "namespace-aliases")
     parseedn-read-str))
 
-(defun cljr--get-aliases-from-middleware ()
-  (when-let (aliases (cljr--call-middleware-for-namespace-aliases))
-    (if (cljr--clj-context-p)
-        (gethash :clj aliases)
-      (gethash :cljs aliases))))
-
 (defun cljr--collapse-to-alias-require-types (sequence)
   "Collapse alias list into a unique mapping of aliases.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1985,23 +1985,25 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
                 nil)))))
 
 (defun cljr--prompt-for-namespace (candidates)
-  "Prompt to select namespace from a list of candidate requires."
+  "Prompt to select namespace from a list of candidate requires if more than 1 option."
   (when candidates
-    (let ((alias-index (make-hash-table :test 'equal)))
-      (dolist (elt candidates)
-        (cl-destructuring-bind (alias-name alias-require lang-contexts) elt
-          (puthash (if lang-contexts
-                       (format "[%s :as %s] (%s)"
+    (if (= (length candidates) 1)
+        (cl-first candidates)
+      (let ((alias-index (make-hash-table :test 'equal)))
+        (dolist (elt candidates)
+          (cl-destructuring-bind (alias-name alias-require lang-contexts) elt
+            (puthash (if lang-contexts
+                         (format "[%s :as %s] (%s)"
+                                 (symbol-name alias-require)
+                                 (symbol-name alias-name)
+                                 (string-join (seq-map #'symbol-name lang-contexts) ","))
+                       (format "[%s :as %s]"
                                (symbol-name alias-require)
-                               (symbol-name alias-name)
-                               (string-join (seq-map #'symbol-name lang-contexts) ","))
-                     (format "[%s :as %s]"
-                             (symbol-name alias-require)
-                             (symbol-name alias-name)))
-                   (list alias-name alias-require)
-                   alias-index)))
-      (let ((ns-require (completing-read "Require: " alias-index)))
-        (gethash ns-require alias-index)))))
+                               (symbol-name alias-name)))
+                     (list alias-name alias-require)
+                     alias-index)))
+        (let ((ns-require (completing-read "Require: " alias-index)))
+          (gethash ns-require alias-index))))))
 
 (defun cljr--js-alias-p (alias)
   (and (cljr--cljs-file-p)
@@ -2087,6 +2089,7 @@ will add the corresponding require statement to the ns form."
         (when (and (not (cljr--in-namespace-declaration-p (concat ":as " short "\b")))
                    (not (cljr--in-namespace-declaration-p (concat ":as-alias " short "\b")))
                    (or (not (eq :prompt cljr-magic-requires))
+                       (not (> (length aliases) 1)) ; already prompted
                        (yes-or-no-p (format "Add %s :as %s to requires?" long short))))
           (save-excursion
             (cljr--insert-in-ns ":require")

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2020,8 +2020,11 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
                (string-remove-prefix "@")))
 
 (defun cljr--magic-requires-lookup-alias ()
-  "Return ((alias ns.candidate1 types) (alias ns.candidate2 types) ...) if we recognize
-the alias in the project."
+  "Generate candidates requires based on the alias at point.
+
+  Constructs a list of alias, namespace, language-contexts
+  triplets from either the middleware or
+  `cljr-magic-require-namespaces'."
   (let ((short (cljr--ns-short-alias-at-point)))
     (unless (or (cljr--resolve-alias short)
                 (cljr--js-alias-p short))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -18,7 +18,7 @@
             (parseedn-read-str
              "{:clj  {t (clojure.test) set (clojure.set) sut (alpha shared)}
                :cljs {t (cljs.test) set (clojure.set) sut (beta shared)}}"))
-    (expect (cljr--namespace-aliases)
+    (expect (cljr--get-aliases-from-middleware)
             :to-equal
             '((t clojure.test (:clj))
               (sut alpha (:clj))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -1,5 +1,6 @@
 (require 'paredit)
 (require 'clj-refactor)
+(require 'buttercup)
 
 ;; NOTE: please remember, without an `it` block, your tests will not be run!
 ;; You can learn about Buttercup's syntax here:
@@ -9,3 +10,19 @@
   (it "returns the ns name of its argument"
     (expect (cljr--ns-name "com.corp.foo") :to-equal "foo")
     (expect (cljr--ns-name "foo") :to-equal "foo")))
+
+(describe "cljr--namespace-aliases"
+  (it "reduces to a unique list from middleware"
+    (spy-on 'cljr--call-middleware-for-namespace-aliases
+            :and-return-value
+            (parseedn-read-str
+             "{:clj  {t (clojure.test) set (clojure.set) sut (alpha shared)}
+               :cljs {t (cljs.test) set (clojure.set) sut (beta shared)}}"))
+    (expect (cljr--namespace-aliases)
+            :to-equal
+            '((t clojure.test (:clj))
+              (sut alpha (:clj))
+              (t cljs.test (:cljs))
+              (set clojure.set (:clj :cljs))
+              (sut beta (:cljs))
+              (sut shared (:clj :cljs))))))


### PR DESCRIPTION
Changes behavior for `cljr--slash` to prompt from a list of candidate requires, while annotating language contexts those requires come from. Previously in `cljc` files, typing `short-name/` would prompt if completion should occur from cljs or clj context and then prompt a second time for an appropriate namespace to require and alias. This shortcuts the context prompt by showing the namespaces for that alias that are used in the project, and annotating whether the source is from a clj or cljs file.

![image](https://user-images.githubusercontent.com/6784/178063079-9a3b7062-e696-45c2-8f7b-4a78094713ee.png)

I believe this solution is preferable to current behavior as often namespaces in cljc files overlap aliases used in both cljs and clj files, yet still defers to the user to determine if the require is appropriate for the current language context. I think this can still be improved when in a `#(:cljs)` context block as we might be able to prefer candidates with the matching context, but it's much nicer than bprompting for context on every / require in a cljc file. However I think some of the context block logic under the previous approach may have been better at detecting the only available require, so that may be a regression. I feel as if the overall workflow allows for more flexibility though if we treat it as:

 1. Check if / preconditions should attempt namespace completion
 2. Generate a list of candidate namespaces annotated with known aliases and language contexts (not filtered by context)
 3. Filter the candidate list based on the name before the / (and possibly context).
 4. Prompt the user to select a namespace from the remaining set 
    a. Shortcutting if only one namespace matches regardless if it is for cljs, clj, or both
 5. Add missing namespace to require

I brought this up in the [clojure Slack](https://clojurians.slack.com/archives/C0617A8PQ/p1647402485682129) a couple months back but forgot to add a corresponding issue. I'm happy to add an issue now if that would be the preferable workflow. For now I'm opening this as a draft PR to solicit review. I'm also happy to cleanup the commit history a bit, but thought it would give some context on how I arrived where I did. Finally, I'm having a lot of trouble updating the ecukes/espud tests that interact with the completing-read as they are only asserting the final state, so it's unclear what's failing in between. Any assistance there would be appreciated.

Thanks for your consideration, hope others find this useful!

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
