### PR TITLE
Prompt for namespaces with language context annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Improve `cljr-slash` for cljs and cljc files when `cljr-magic-require-prompts-include-context` is enabled [#525](https://github.com/clojure-emacs/clj-refactor.el/pull/525).
+
 ## 3.5.4
 
 * [Upgrade refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.5.3/CHANGELOG.md#353).

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2152,10 +2152,8 @@ will add the corresponding require statement to the ns form."
     (if cljr-magic-require-prompts-includes-context
         (when-let (selection (cljr--magic-prompt-or-select-namespace
                               (cljr--magic-require-candidates alias-ref)))
-          (let ((alias (symbol-name (cl-first selection)))
-                (namespace (cl-second selection)))
-            (when (and (not (cljr--in-namespace-declaration-p (concat ":as " alias "\b")))
-                       (not (cljr--in-namespace-declaration-p (concat ":as-alias " alias "\b"))))
+          (cl-destructuring-bind (alias namespace _) selection
+            (unless (cljr--resolve-alias (symbol-name alias))
               (cljr--insert-require-libspec (format "[%s :as %s]" namespace alias)))))
       (when-let (aliases (cljr--magic-requires-lookup-alias alias-ref))
         (let ((short (cl-first aliases))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2021,7 +2021,7 @@ The key of the table will be presented to the user by
 `completing-read', the value is the intended selection value."
   (let ((completions (make-hash-table :test 'equal)))
     (dolist (elt candidates)
-      (cl-destructuring-bind (alias-name alias-require lang-contexts) elt
+      (seq-let (alias-name alias-require lang-contexts) elt
         (puthash (if lang-contexts
                      (format "[%s :as %s] (%s)"
                              (symbol-name alias-require)
@@ -2153,7 +2153,7 @@ will add the corresponding require statement to the ns form."
     (if cljr-magic-require-prompts-includes-context
         (when-let (selection (cljr--magic-prompt-or-select-namespace
                               (cljr--magic-require-candidates alias-ref)))
-          (cl-destructuring-bind (alias namespace _) selection
+          (seq-let (alias namespace _) selection
             (unless (cljr--resolve-alias (symbol-name alias))
               (cljr--insert-require-libspec (format "[%s :as %s]" namespace alias)))))
       (when-let (aliases (cljr--magic-requires-lookup-alias alias-ref))

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -36,6 +36,7 @@
 (require 'yasnippet)
 (require 'paredit)
 (require 'multiple-cursors-core)
+(require 'cl-macs)
 (require 'clojure-mode)
 (require 'cider)
 (require 'parseedn)

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -173,18 +173,18 @@
 (describe "cljr--list-namespace-aliases"
   (it "reduces to a unique list from middleware"
     (spy-on 'cljr--call-middleware-for-namespace-aliases
-             :and-return-value
-             (parseedn-read-str
-              "{:clj  {t (clojure.test) set (clojure.set) sut (alpha shared)}
+            :and-return-value
+            (parseedn-read-str
+             "{:clj  {t (clojure.test) set (clojure.set) sut (alpha shared)}
                :cljs {t (cljs.test) set (clojure.set) sut (beta shared)}}"))
     (expect (cljr--list-namespace-aliases)
             :to-equal
-            '((t clojure.test (:clj))
-              (sut alpha (:clj))
+            '((sut beta (:cljs))
               (t cljs.test (:cljs))
-              (set clojure.set (:clj :cljs))
-              (sut beta (:cljs))
-              (sut shared (:clj :cljs))))))
+              (sut alpha (:clj))
+              (sut shared (:cljs :clj))
+              (set clojure.set (:cljs :clj))
+              (t clojure.test (:clj))))))
 
 (describe "cljr--magic-require-candidates"
   (it "returns an empty list if no matching aliases"

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -260,6 +260,24 @@
       (expect (cljr--magic-prompt-or-select-namespace '((a b.a (:clj))))
               :to-equal '(a b.a (:clj))))))
 
+(defun cljr--test-resolve (alias)
+  (cljr--with-clojure-temp-file "foo.clj"
+    (insert "(ns foo (:require [a.a :as a] [a.b :as-alias b] [a.b.c :as b.c]))")
+    (cljr--resolve-alias alias)))
+
+(describe "cljr--resolve-alias"
+  (it "returns nil on no matching alias"
+    (expect (cljr--test-resolve "missing") :to-be nil))
+
+  (it "finds alias :as `a'"
+    (expect (cljr--test-resolve "a") :to-equal "a.a"))
+
+  (it "finds alias :as-alias `b'"
+    (expect (cljr--test-resolve "b") :to-equal "a.b"))
+
+  (it "finds dotted alias `b.c'"
+    (expect (cljr--test-resolve "b.c") :to-equal "a.b.c")))
+
 (describe "cljr-slash"
   (describe "with prompts including context"
     (before-each (setq cljr-magic-require-prompts-includes-context t))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -169,3 +169,19 @@
               (insert "(ns foo)")
               (cljr--unresolved-alias-ref "js"))
             :to-equal "js")))
+
+(describe "cljr--list-namespace-aliases"
+  (it "reduces to a unique list from middleware"
+    (spy-on 'cljr--call-middleware-for-namespace-aliases
+             :and-return-value
+             (parseedn-read-str
+              "{:clj  {t (clojure.test) set (clojure.set) sut (alpha shared)}
+               :cljs {t (cljs.test) set (clojure.set) sut (beta shared)}}"))
+    (expect (cljr--list-namespace-aliases)
+            :to-equal
+            '((t clojure.test (:clj))
+              (sut alpha (:clj))
+              (t cljs.test (:cljs))
+              (set clojure.set (:clj :cljs))
+              (sut beta (:cljs))
+              (sut shared (:clj :cljs))))))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -179,11 +179,11 @@
                :cljs {t (cljs.test) set (clojure.set) sut (beta shared)}}"))
     (expect (cljr--list-namespace-aliases)
             :to-equal
-            '((sut beta (:cljs))
-              (t cljs.test (:cljs))
+            '((set clojure.set (:clj :cljs))
               (sut alpha (:clj))
-              (sut shared (:cljs :clj))
-              (set clojure.set (:cljs :clj))
+              (sut beta (:cljs))
+              (sut shared (:clj :cljs))
+              (t cljs.test (:cljs))
               (t clojure.test (:clj))))))
 
 (describe "cljr--magic-require-candidates"


### PR DESCRIPTION
Rewrites #521 using a defcustom `cljr-magic-require-prompts-includes-context`. This is also the followup to #522, which introduced refactors to cleanly apply this change. This is an improvement to the `cljr-slash` magic require functionality, where inserting a slash after an alias used elsewhere in the project will be automatically added as a namespace alias for the current file.

![image](https://user-images.githubusercontent.com/6784/178362534-fd488def-4032-4536-a5a3-603e936348a8.png)

If the defcustom `cljr-magic-require-prompts-includes-context` is set to `t`, `cljr-slash` will prompt for namespace completion if there is more then one match or short-circuit if only one. Instead of first prompting for language context, it now shows all the possible contexts `(:clj)`, `(:cljs)`, and `(:clj, cljs)` the alias has been referred to elsewhere in the project along with the recommended libspec. Aliases that are shared across more then one language with the same namespace are now grouped into a single option, allowing `cljr-slash` to short-circuit and add the require without prompting.

If the defcustom is false, it uses the existing behavior, which if in a `cljc` file will first prompt for the language context, and then prompt for potential libspec entries to resolve the alias.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
