### PR TITLE
Improved alias detection for cljr--ns-alias-at-point

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1970,10 +1970,14 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
 (defun cljr--ns-alias-at-point ()
   "Returns the (alias)/ just prior to the point excluding the trailing slash."
   (thread-last (buffer-substring-no-properties
-                (cljr--point-after 'paredit-backward)
+                (cljr--point-after
+                 '(skip-syntax-backward "w_"))  ;; word or symbol constituent
                 (1- (point)))
+               (string-remove-prefix "`")
+               (string-remove-prefix "#'")
                (string-remove-prefix "::")
-               (string-remove-prefix "@")))
+               (string-remove-prefix ":")
+               (string-remove-prefix "'")))
 
 (defun cljr--magic-requires-lookup-alias (short)
   "Generate a mapping from alias to candidate namespaces.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1969,15 +1969,14 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
 
 (defun cljr--ns-alias-at-point ()
   "Returns the (alias)/ just prior to the point excluding the trailing slash."
-  (thread-last (buffer-substring-no-properties
-                (cljr--point-after
-                 '(skip-syntax-backward "w_"))  ;; word or symbol constituent
-                (1- (point)))
-               (string-remove-prefix "`")
-               (string-remove-prefix "#'")
-               (string-remove-prefix "::")
-               (string-remove-prefix ":")
-               (string-remove-prefix "'")))
+  (buffer-substring-no-properties
+   (cljr--point-after
+    ;; word or symbol constituent
+    '(skip-syntax-backward "w_")
+    ;; ignore prefix digits, #', ', `, :, and ::, that are not part of the
+    ;; symbol, and can occur in various orderings.
+    '(re-search-forward "^\[0-9`':#\]*" nil t))
+   (1- (point))))
 
 (defun cljr--magic-requires-lookup-alias (short)
   "Generate a mapping from alias to candidate namespaces.

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -105,6 +105,20 @@
 
   (it "removes quasiquote"
     (expect (cljr--alias-here "`alias/")
+            :to-equal "alias"))
+
+  (it "ignores prefix digits"
+    (expect (cljr--alias-here "0alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "01alias/")
+            :to-equal "alias"))
+
+  (it "ignores multiple prefixes"
+    (expect (cljr--alias-here "'#alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "'#0alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "':alias/")
             :to-equal "alias")))
 
 (describe "cljr--unresolved-alias-ref"


### PR DESCRIPTION
Addresses https://github.com/clojure-emacs/clj-refactor.el/issues/524.

Prevously ns aliases could include quasiquote, sharp-quote and was not
identifying dotted aliases. After reading through the docs on valid namespace
alias, it appears aliases can be any valid symbol. I tested briefly, and all of the
following namespace aliases are valid in both Clojure and Clojurescript.

foo.bar or foo.bar.baz
test? or ?test or a?b
a:b (a::b is legal in cljs only)
tl'an or name'
l33t or a1
foo$bar

I *suspect* that clojure-mode would benefit from providing a robust
clojure-symbol-at-point which could be re-used here. It has a robust symbol
regexp in `clojure--sym-regexp`, which could then be trimmed of leading : and
such, but that is internal to clojure-mode, so I thought it better if it could
be exposed there before using it here.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
