### PR TITLE
Fix regex for removing prefix from ns alias

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 # Default actions to perform on each Emacs version
 default: &default-steps
+  environment:
+    TERM: xterm
   steps:
     - checkout
     - run: apt-get update && apt-get install make

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1975,7 +1975,7 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
     '(skip-syntax-backward "w_")
     ;; ignore prefix digits, #', ', `, :, and ::, that are not part of the
     ;; symbol, and can occur in various orderings.
-    '(re-search-forward "^\[0-9`':#\]*" nil t))
+    '(re-search-forward "[0-9`':#]*" nil t))
    (1- (point))))
 
 (defun cljr--magic-requires-lookup-alias (short)

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -65,7 +65,9 @@
 
   (it "removes prefix :: (namespaced keyword)"
     (expect (cljr--alias-here "::ns-name/")
-            :to-equal "ns-name"))
+            :to-equal "ns-name")
+    (expect (cljr--alias-here "(::util/")
+            :to-equal "util"))
 
   (it "includes question-mark"
     (expect (cljr--alias-here "ns-name?/")
@@ -77,7 +79,9 @@
 
   (it "removes prefix : (keyword)"
     (expect (cljr--alias-here ":ns-name/")
-            :to-equal "ns-name"))
+            :to-equal "ns-name")
+    (expect (cljr--alias-here "(:alias/")
+            :to-equal "alias"))
 
   (it "allows infix :"
     (expect (cljr--alias-here "foo:bar/")
@@ -111,7 +115,15 @@
     (expect (cljr--alias-here "0alias/")
             :to-equal "alias")
     (expect (cljr--alias-here "01alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "{01alias/")
             :to-equal "alias"))
+
+  (it "allows internal & suffix digits"
+    (expect (cljr--alias-here "alias0/")
+            :to-equal "alias0")
+    (expect (cljr--alias-here "ali0as/")
+            :to-equal "ali0as"))
 
   (it "ignores multiple prefixes"
     (expect (cljr--alias-here "'#alias/")
@@ -119,6 +131,12 @@
     (expect (cljr--alias-here "'#0alias/")
             :to-equal "alias")
     (expect (cljr--alias-here "':alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "#':alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "(#':alias/")
+            :to-equal "alias")
+    (expect (cljr--alias-here "([#'::alias/")
             :to-equal "alias")))
 
 (describe "cljr--unresolved-alias-ref"


### PR DESCRIPTION
Fixes failing test in https://github.com/clojure-emacs/clj-refactor.el/pull/526.

The leading ^ matches the beginning of the line, and not from the current point.
Many of the examples were inserted as a bare word and not tested in the context
they would usually appear.

Also removed unnecessary escaping of character class [] brackets.

I've run buttercup unit-tests and the feature specs locally. However I was unable to get CircleCI to run integration tests for this branch due to the following environment issue:
```
cask exec ecukes --no-win
Please set the environment variable TERM; see 'tset'.
make: *** [Makefile:32: integration-tests] Error 1
```

It did however, pass unit tests. Is there an additional setting in CircleCI to fix that I need to set in my configuration?

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!