### PR TITLE
`cljr-slash` using `suggest-libspecs` middleware op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#532] Introduce `cljr-slash-uses-suggest-libspec` to use the language context aware `suggest-libspec` middleware for alias to libspec suggestions.
+
 ## 3.5.4
 
 * [Upgrade refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.5.3/CHANGELOG.md#353).

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1965,13 +1965,19 @@ following this convention: https://stuartsierra.com/2015/05/10/clojure-namespace
     parseedn-read-str))
 
 (defun cljr--call-middleware-suggest-libspec (alias-ref language-context)
-  "Suggest libspec entries for an `alias-ref' in a `language-context'.
+  "Suggest namespace require libspecs for an alias.
 
-Returns a candidate list of libspec entry strings. `alias-ref' is
-a string representing a namespace alias. `language-context' is a
-2 element list representing the language context of the buffer,
-followed by the language context at the current point. Assume
-same context as buffer if context at current point is nil.
+Returns a candidate list of libspec entry strings. An alias
+\"set\" might return (\"[clojure.set :as set]\").
+
+`alias-ref' is a string representing a namespace alias entered by
+the user.
+
+`language-context' is a 2 element tuple representing the language
+context of the buffer, and the context of the reader conditional
+where the alias is being used. Assume same context as
+buffer if context at current point is nil. See
+`cljr--language-context-at-point' for details on this tuple.
 
 Passes through the custom `cljr-magic-require-namespaces' so that
 users can specify default recommended alias prefixes that may not
@@ -1994,7 +2000,14 @@ appear in the project yet."
 
 Returns a tuple, the first value represents the language context
 of the file, the second represents the language context at the
-current point if it is within a reader conditional. If a given value is unknown, it will be expressed as nil"
+current point if it is within a reader conditional. If a given
+value is unknown, it will be expressed as nil.
+
+Reader conditionals are forms like #?(:clj (expr)) or
+#?@(:cljs (expr) :default (expr2)) (see
+URL`https://clojure.org/guides/reader_conditionals'). As
+example, `(\"cljc\", \"cljs\")' represents a point in a cljs path
+of a reader conditional inside of a cljc file."
   (list (cond ((cljr--cljc-file-p)
                "cljc")
               ((cljr--cljs-file-p)

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -75,7 +75,7 @@ Any other non-nil value means to add the form without asking."
                  (const :tag "false" nil)))
 
 (defcustom cljr-slash-uses-suggest-libspec nil
-  "If t, `cljr-slash' magic require functionality will use the
+  "If t, `cljr-slash' magic require functionality will use the newer
 `cljr-suggest-libspec' middleware op instead of the
 `namespace-aliases' op."
   :type 'boolean
@@ -1994,8 +1994,7 @@ appear in the project yet."
 
 Returns a tuple, the first value represents the language context
 of the file, the second represents the language context at the
-current point if it is within a reader conditional. If either
-value is unknown, return nil."
+current point if it is within a reader conditional. If a given value is unknown, it will be expressed as nil"
   (list (cond ((cljr--cljc-file-p)
                "cljc")
               ((cljr--cljs-file-p)

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1982,7 +1982,8 @@ buffer if context at current point is nil. See
 Passes through the custom `cljr-magic-require-namespaces' so that
 users can specify default recommended alias prefixes that may not
 appear in the project yet."
-  (seq-let (buffer-context point-context) language-context
+  (let ((buffer-context (car language-context))
+        (point-context (cadr language-context)))
     (thread-first
       "cljr-suggest-libspecs"
       cljr--ensure-op-supported

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2015,11 +2015,14 @@ of a reader conditional inside of a cljc file."
                "cljs")
               ((cljr--clj-file-p)
                "clj"))
-        (when (cljr--point-in-reader-conditional-p)
-          (cond ((cljr--point-in-reader-conditional-branch-p :clj)
-                 "clj")
-                ((cljr--point-in-reader-conditional-branch-p :cljs)
-                 "cljs")))))
+        nil
+        ;; See https://github.com/clojure-emacs/clj-refactor.el/issues/533
+        ;; (when (cljr--point-in-reader-conditional-p)
+        ;;   (cond ((cljr--point-in-reader-conditional-branch-p :clj)
+        ;;          "clj")
+        ;;         ((cljr--point-in-reader-conditional-branch-p :cljs)
+        ;;          "cljs")))
+        ))
 
 (defun cljr--prompt-or-select-libspec (candidates)
   "Prompts for namespace selection or returns only candidate.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1982,6 +1982,25 @@ appear in the project yet."
       parseedn-read-str
       (seq-into 'list))))
 
+(defun cljr--language-context-at-point ()
+  "Detects the current language-context at a given point.
+
+Returns a tuple, the first value represents the language context
+of the file, the second represents the language context at the
+current point if it is within a reader conditional. If either
+value is unknown, return nil."
+  (list (cond ((cljr--cljc-file-p)
+               "cljc")
+              ((cljr--cljs-file-p)
+               "cljs")
+              ((cljr--clj-file-p)
+               "clj"))
+        (when (cljr--point-in-reader-conditional-p)
+          (cond ((cljr--point-in-reader-conditional-branch-p :clj)
+                 "clj")
+                ((cljr--point-in-reader-conditional-branch-p :cljs)
+                 "cljs")))))
+
 (defun cljr--get-aliases-from-middleware ()
   (when-let (aliases (cljr--call-middleware-for-namespace-aliases))
     (if (cljr--clj-context-p)

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -274,14 +274,13 @@
               :to-equal "[a.a :as a]"))))
 
 (describe "cljr-slash"
-  (before-each (setq cljr-slash-uses-suggest-libspec t))
-  (after-each (setq cljr-slash-uses-suggest-libspec nil))
   (it "inserts single selection from suggest-libspec"
     (spy-on 'cljr--call-middleware-suggest-libspec
             :and-return-value (parseedn-read-str "[\"[bar.alias :as alias]\"]"))
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo)\nalias|"
-        (cljr-slash))
+        (let ((cljr-slash-uses-suggest-libspec t))
+          (cljr-slash)))
       (expect (buffer-string) :to-equal "(ns foo
   (:require [bar.alias :as alias]))
 alias/")))
@@ -293,7 +292,8 @@ alias/")))
             :and-return-value "[baz.example :as ex]")
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo)\nex|"
-        (cljr-slash))
+        (let ((cljr-slash-uses-suggest-libspec t))
+          (cljr-slash)))
       (expect (buffer-string) :to-equal "(ns foo
   (:require [baz.example :as ex]))
 ex/")))
@@ -305,7 +305,8 @@ ex/")))
             :and-return-value "[baz.example :as ex :refer [a b c] ]")
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo)\nex|"
-        (cljr-slash))
+        (let ((cljr-slash-uses-suggest-libspec t))
+          (cljr-slash)))
       (expect (buffer-string) :to-equal "(ns foo
   (:require [baz.example :as ex :refer [a b c] ]))
 ex/"))))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -141,31 +141,31 @@
 
 (describe "cljr--unresolved-alias-ref"
   (it "returns unresolved alias reference"
-    (expect (cljr--with-clojure-temp-file "foo.clj"
-              (insert "(ns foo)")
-              (cljr--unresolved-alias-ref "ns-name"))
-            :to-equal "ns-name"))
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo)")
+      (expect (cljr--unresolved-alias-ref "ns-name")
+              :to-equal "ns-name")))
 
   (it "returns nil for resolved alias"
-    (expect (cljr--with-clojure-temp-file "foo.clj"
-              (insert "(ns foo (:require [user.ns-name :as ns-name]))")
-              (cljr--unresolved-alias-ref "ns-name"))
-            :to-be nil))
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo (:require [user.ns-name :as ns-name]))")
+      (expect (cljr--unresolved-alias-ref "ns-name")
+              :to-be nil)))
 
   (it "returns nil for js alias in cljs file."
-    (expect (cljr--with-clojure-temp-file "foo.cljs"
-              (insert "(ns foo)")
-              (cljr--unresolved-alias-ref "js"))
-            :to-be nil))
+    (cljr--with-clojure-temp-file "foo.cljs"
+      (insert "(ns foo)")
+      (expect (cljr--unresolved-alias-ref "js")
+              :to-be nil)))
 
   (it "returns js for js alias in clj file."
-    (expect (cljr--with-clojure-temp-file "foo.clj"
-              (insert "(ns foo)")
-              (cljr--unresolved-alias-ref "js"))
-            :to-equal "js"))
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo)")
+      (expect (cljr--unresolved-alias-ref "js")
+              :to-equal "js")))
 
   (it "returns js for js alias in cljc file."
-    (expect (cljr--with-clojure-temp-file "foo.cljc"
-              (insert "(ns foo)")
-              (cljr--unresolved-alias-ref "js"))
-            :to-equal "js")))
+    (cljr--with-clojure-temp-file "foo.cljc"
+      (insert "(ns foo)")
+      (expect (cljr--unresolved-alias-ref "js")
+              :to-equal "js"))))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -253,25 +253,28 @@
     (spy-on 'completing-read :and-return-value "[a.a :as a]")
     (expect (cljr--prompt-or-select-libspec '("[a.a :as a]"
                                               "[a.b :as b]"))
-            :to-equal "[a.a :as a]"))
+            :to-equal "[a.a :as a]")
+    (expect 'completing-read :to-have-been-called-times 1))
 
   (it "returns user content from prompt regardless of candidates"
     (spy-on 'completing-read :and-return-value "[alpha :as a]")
     (expect (cljr--prompt-or-select-libspec
              '("[a.a :as a]"
                "[a.b :as b]"))
-            :to-equal "[alpha :as a]"))
+            :to-equal "[alpha :as a]")
+    (expect 'completing-read :to-have-been-called-times 1))
 
   (it "short-circuits if only one candidate matches"
-    (expect 'completing-read :to-have-been-called-times 0)
     (expect (cljr--prompt-or-select-libspec '("[a.a :as a]"))
-            :to-equal "[a.a :as a]"))
+            :to-equal "[a.a :as a]")
+    (expect 'completing-read :to-have-been-called-times 0))
 
   (it "prompts anyway if `cljr-magic-requires' is `:prompt'"
     (spy-on 'completing-read :and-return-value "[a.a :as a]")
     (let ((cljr-magic-requires :prompt))
       (expect (cljr--prompt-or-select-libspec '("[a.a :as a]"))
-              :to-equal "[a.a :as a]"))))
+              :to-equal "[a.a :as a]"))
+    (expect 'completing-read :to-have-been-called-times 1)))
 
 (describe "cljr-slash"
   (it "inserts single selection from suggest-libspec"

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -197,25 +197,26 @@
       (expect (cljr--language-context-at-point)
               :to-equal '("cljc" nil))))
 
-  (it "identifies a cljc file with a cljs context"
+  ;; Marked as pending per discussion in https://github.com/clojure-emacs/clj-refactor.el/issues/533
+  (xit "identifies a cljc file with a cljs context"
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo) #?(:cljs (Math/log|))"
         (expect (cljr--language-context-at-point)
                 :to-equal '("cljc" "cljs")))))
 
-  (it "identifies a cljc file with a clj context"
+  (xit "identifies a cljc file with a clj context"
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo) #?(:clj (Math/log|))"
         (expect (cljr--language-context-at-point)
                 :to-equal '("cljc" "clj")))))
 
-  (it "identifies a nested context with two branches present"
+  (xit "identifies a nested context with two branches present"
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo) #?(:cljs (Math/log|) :clj 1)"
         (expect (cljr--language-context-at-point)
                 :to-equal '("cljc" "cljs")))))
 
-  (it "identifies a nested context with an alternate branch proceeding"
+  (xit "identifies a nested context with an alternate branch proceeding"
     (cljr--with-clojure-temp-file "foo.cljc"
       (with-point-at "(ns foo) #?(:clj 1 :cljs (Math/log|))"
         (expect (cljr--language-context-at-point)


### PR DESCRIPTION
Implements https://github.com/clojure-emacs/clj-refactor.el/issues/531. ~~Still need to add changelog/readme updates if this approach is accepted.~~

If the defcustom `cljr-slash-uses-suggest-libspec` is enabled, `cljr-slash` will query the new `suggest-libspec` middleware op for suggested namespaces.

Currently it sends over the entire `cljr-magic-require-namespaces` as the preferred-aliases map, that may require pre-processing at some point, but the placeholder seems correct. It also correctly identifies if code block is in a conditional language context, and provides that information to the middleware to in order to assist generating recommendations.

Finally, as it's using `completing-read` to select namespaces, if the user inserts their own content into the response, that will be inserted as the new libspec. This allows the user to reference a new libspec, or edit it to include refers or require-macro. In the future, it might make sense to use the universal argument to temporarily force `cljr-magic-requires` to use :prompt, allowing a user to insert a require of their own choice more easily.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] Fix wiki docs to reference the `cljr-slash-uses-suggest-libspec` defcustom

Thanks!
