### PR TITLE
Add clojure.math to magic require namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.6.1
+
+- Add the [clojure.math namespace](https://clojure.github.io/clojure/clojure.math-api.html) to magic requires (new with Clojure 1.11.0)
+
 ## 3.6.0
 
 - [#532] Introduce `cljr-slash-uses-suggest-libspec` to use the language context aware `suggest-libspec` middleware for alias to libspec suggestions.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -83,6 +83,7 @@ Any other non-nil value means to add the form without asking."
 
 (defcustom cljr-magic-require-namespaces
   '(("io"   . "clojure.java.io")
+    ("math" . "clojure.math")
     ("set"  . "clojure.set")
     ("str"  . "clojure.string")
     ("walk" . "clojure.walk")


### PR DESCRIPTION
Clojure 1.11.0 provides the new clojure.math namespace. Users will expect that it's magically required by "math", analog to the other builtins.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
