### PR TITLE
`cljr--reader-conditional-context` identifies current language

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1947,6 +1947,43 @@ FEATURE is either :clj or :cljs."
                                                (list "clj" "cljs"))
                         "clj"))))))
 
+(defun cljr--beginning-of-reader-conditional ()
+  "Return position of beginning of containing reader conditional.
+
+Otherwise `nil' if outside of reader conditional."
+  (save-excursion
+    (let ((reader-start nil))
+      (while (not (or reader-start (cljr--top-level-p)))
+        (backward-up-list)
+        (when (looking-back (regexp-opt (list "#\?@" "#\?")) (- (point) 3))
+          (setq reader-start (1+ (point)))))
+      reader-start)))
+
+(defun cljr--reader-conditional-context ()
+  "Returns keyword name of closest language context containing point.
+
+Otherwise `nil' if outside conditional or unable to find a
+context. Valid outputs include, but are not limited to `:clj',
+`:cljs', `:cljr', `:bb', or `:default' as strings."
+  (save-excursion
+    (let ((starting-point (point))
+          (language nil))
+      (when-let ((reader-start (cljr--beginning-of-reader-conditional)))
+        (goto-char reader-start)
+        (while (and (<= (point) starting-point) (not language))
+          (if-let ((current (cider-symbol-at-point)))
+              ;; attempt to move forward a language/context pair. Accept if
+              ;; starting point was before next language pair, or if last pair.
+              (when (< starting-point
+                       (condition-case nil
+                           (progn (cider-start-of-next-sexp 2)
+                                  (point)) ; start of next context
+                         (error (1+ starting-point))))
+                (setq language current))
+            ;; otherwise move out of bounds of search to exit without language
+            (goto-char (1+ starting-point))))
+        language))))
+
 (defun cljr--aget (map key)
   (cdr (assoc key map)))
 
@@ -2016,14 +2053,8 @@ of a reader conditional inside of a cljc file."
                "cljs")
               ((cljr--clj-file-p)
                "clj"))
-        nil
-        ;; See https://github.com/clojure-emacs/clj-refactor.el/issues/533
-        ;; (when (cljr--point-in-reader-conditional-p)
-        ;;   (cond ((cljr--point-in-reader-conditional-branch-p :clj)
-        ;;          "clj")
-        ;;         ((cljr--point-in-reader-conditional-branch-p :cljs)
-        ;;          "cljs")))
-        ))
+        (when-let ((context (cljr--reader-conditional-context)))
+          (string-remove-prefix ":" context))))
 
 (defun cljr--prompt-or-select-libspec (candidates)
   "Prompts for namespace selection or returns only candidate.


### PR DESCRIPTION
Addresses problems identified in
https://github.com/clojure-emacs/clj-refactor.el/issues/533.

Previously, `cljr--goto-reader-conditional` and`cljr--point-in-reader-conditional-branch-p` appeared to have problems with infinite loops as they looked for specific language values in the reader conditional.

`cljr--reader-conditional-context` starts at the beginning of the closest enclosing reader-conditional, and walks through each language, context pair returning the language name if the point is somewhere between the start of the language keyword or the next language pair. It will also bail and return nil if it searches beyond the scope of the reader-conditional or there is no language symbol it can identify.

`cljr--language-context-at-point` has been amended to use the `cljr--reader-conditional-context` to return both the language of the file & the current context to search from.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [ ] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
