### PR TITLE
Deprecate unused reader-conditional functions and transition to new

### DIFF
--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -234,6 +234,8 @@ won't run if there is a broken namespace in the project."
   :type 'boolean
   :safe #'booleanp)
 
+;; TODO: remove after `cljr--clj-context-p' is deprecated by enabling
+;; `cljr-slash-uses-suggest-libspec'.
 (defcustom cljr-assume-language-context nil
   "If set to 'clj' or 'cljs', clj-refactor will use that value in situations
   where the language context is ambiguous. If set to nil, a popup will be
@@ -1894,6 +1896,8 @@ front of function literals and sets."
 (defun cljr--magic-requires-re ()
   (regexp-opt (seq-map 'car cljr-magic-require-namespaces)))
 
+;; TODO: remove after `cljr--get-aliases-from-middleware' is deprecated by
+;; enabling `cljr-slash-uses-suggest-libspec'.
 (defun cljr--clj-context-p ()
   "Is point in a clj context?"
   (or (cljr--clj-file-p)
@@ -2051,6 +2055,7 @@ is not set to `:prompt'."
     '(re-search-forward "[0-9`':#]*" nil t))
    (1- (point))))
 
+;; TODO: deprecated after enabling `cljr-slash-uses-suggest-libspec'
 (defun cljr--magic-requires-lookup-alias (short)
   "Generate a mapping from alias to candidate namespaces.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -4343,14 +4343,6 @@ If injecting the dependencies is not preferred set `cljr-inject-dependencies-at-
 (define-obsolete-function-alias 'cljr-cycle-if 'clojure-cycle-if "2.3.0")
 (make-obsolete 'cljr-cycle-coll "reworked into convert collection to list, quoted list, map, vector, set in Clojure mode." "2.3.0")
 
-(define-obsolete-function-alias 'cljr--point-in-reader-conditional-p 'cljr--reader-conditional-context "3.6.0")
-(make-obsolete 'cljr--point-in-reader-conditional-branch-p
-               "assert a return value of (cljr--reader-conditional-context)"
-               "3.6.0")
-(make-obsolete 'cljr--goto-reader-conditional
-               "use cljr--beginning-of-reader-conditional"
-               "3.6.0")
-
 ;; ------ minor mode -----------
 ;;;###autoload
 (define-minor-mode clj-refactor-mode

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1910,31 +1910,13 @@ Return the value of point if we moved."
       (goto-char start)
       nil)))
 
-(defun cljr--point-in-reader-conditional-branch-p (feature)
-  "Is point in a reader conditional branch for FEATURE?
-
-FEATURE is either :clj or :cljs."
-  (cl-assert (or (eq feature :clj) (eq feature :cljs)) nil
-             "FEATURE has to be either :clj or :cljs.  Received: %s" feature)
-  (save-excursion
-    (let ((start-reader-conditional
-           (cljr--point-after 'cljr--goto-reader-conditional))
-          (other (if (eq feature :clj) ":cljs\\b" ":clj\\b"))
-          found)
-      (when start-reader-conditional
-        (while (not (or (setq found (looking-at-p (format "%s\\b" feature)))
-                        (looking-at-p other)
-                        (< (point) start-reader-conditional)))
-          (paredit-backward))
-        found))))
-
 (defun cljr--clj-context-p ()
   "Is point in a clj context?"
   (or (cljr--clj-file-p)
       (when (cljr--cljc-file-p)
         (cond
          ((cljr--beginning-of-reader-conditional)
-          (cljr--point-in-reader-conditional-branch-p :clj))
+          (string-equal (cljr--reader-conditional-context) ":clj"))
          (cljr-assume-language-context
           (string-equal cljr-assume-language-context "clj"))
          (t
@@ -4373,6 +4355,9 @@ If injecting the dependencies is not preferred set `cljr-inject-dependencies-at-
 (make-obsolete 'cljr-cycle-coll "reworked into convert collection to list, quoted list, map, vector, set in Clojure mode." "2.3.0")
 
 (define-obsolete-function-alias 'cljr--point-in-reader-conditional-p 'cljr--reader-conditional-context "3.6.0")
+(make-obsolete 'cljr--point-in-reader-conditional-branch-p
+               "assert a return value of (cljr--reader-conditional-context)"
+               "3.6.0")
 
 ;; ------ minor mode -----------
 ;;;###autoload

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1894,22 +1894,6 @@ front of function literals and sets."
 (defun cljr--magic-requires-re ()
   (regexp-opt (seq-map 'car cljr-magic-require-namespaces)))
 
-(defun cljr--goto-reader-conditional ()
-  "Move point just before #?.
-
-Return the value of point if we moved."
-  (let ((start (point))
-        found)
-    (while (not (or found (cljr--top-level-p)))
-      (paredit-backward-up)
-      (when (looking-back (regexp-opt (list "#\?@" "#\?")) (point-at-bol))
-        (paredit-backward)
-        (setq found t)))
-    (if found
-        (point)
-      (goto-char start)
-      nil)))
-
 (defun cljr--clj-context-p ()
   "Is point in a clj context?"
   (or (cljr--clj-file-p)
@@ -4357,6 +4341,9 @@ If injecting the dependencies is not preferred set `cljr-inject-dependencies-at-
 (define-obsolete-function-alias 'cljr--point-in-reader-conditional-p 'cljr--reader-conditional-context "3.6.0")
 (make-obsolete 'cljr--point-in-reader-conditional-branch-p
                "assert a return value of (cljr--reader-conditional-context)"
+               "3.6.0")
+(make-obsolete 'cljr--goto-reader-conditional
+               "use cljr--beginning-of-reader-conditional"
                "3.6.0")
 
 ;; ------ minor mode -----------

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1910,11 +1910,6 @@ Return the value of point if we moved."
       (goto-char start)
       nil)))
 
-(defun cljr--point-in-reader-conditional-p ()
-  "Return t if point is inside a reader conditional."
-  (save-excursion
-    (cljr--goto-reader-conditional)))
-
 (defun cljr--point-in-reader-conditional-branch-p (feature)
   "Is point in a reader conditional branch for FEATURE?
 
@@ -1938,7 +1933,7 @@ FEATURE is either :clj or :cljs."
   (or (cljr--clj-file-p)
       (when (cljr--cljc-file-p)
         (cond
-         ((cljr--point-in-reader-conditional-p)
+         ((cljr--beginning-of-reader-conditional)
           (cljr--point-in-reader-conditional-branch-p :clj))
          (cljr-assume-language-context
           (string-equal cljr-assume-language-context "clj"))
@@ -4376,6 +4371,8 @@ If injecting the dependencies is not preferred set `cljr-inject-dependencies-at-
 (define-obsolete-function-alias 'cljr-cycle-privacy 'clojure-cycle-privacy "2.3.0")
 (define-obsolete-function-alias 'cljr-cycle-if 'clojure-cycle-if "2.3.0")
 (make-obsolete 'cljr-cycle-coll "reworked into convert collection to list, quoted list, map, vector, set in Clojure mode." "2.3.0")
+
+(define-obsolete-function-alias 'cljr--point-in-reader-conditional-p 'cljr--reader-conditional-context "3.6.0")
 
 ;; ------ minor mode -----------
 ;;;###autoload


### PR DESCRIPTION
Cleanup PR to close out https://github.com/clojure-emacs/clj-refactor.el/issues/533. I initially marked each function as obsolete but then remembered these are conventionally private API so probably not worth the obsolete tag. We can re-apply obsolete if needed though by reverting the last commit. I also left TODOs on the remaining deprecated reader-conditional functions like `cljr--clj-context-p` to clarify they are being removed and when. Once we switch to enable `cljr-slash-uses-suggest-libspec`, there are quite a number of functions that can be removed, but I wanted to mark the ones specifically related to context in this PR.

One other thing, tests are passing on CI on my fork, but it appears tests are failing on the official repo because the circle CI ssh key for github is invalidated, and hasn't been refreshed? I suspect that requires a circle ci account owner for the main repo to resolve.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
-- no need for tests on removed functions
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
-- I can add a changelog/readme if needed but it's not changing user-visible functionality.
