### PR TITLE
Enable `cljr-slash-uses-suggest-libspec` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#554](https://github.com/clojure-emacs/clj-refactor.el/pull/554): Enable `cljr-slash-uses-suggest-libspec` by default
+
 ## 3.10.0
 
 * [#552](https://github.com/clojure-emacs/clj-refactor.el/issues/552): support TRAMP connections.

--- a/feature/feature.el
+++ b/feature/feature.el
@@ -1,1 +1,2 @@
+;; -*- lexical-binding: t -*-
 (provide 'feature)

--- a/features/magic-requires-in-cljc-files.feature
+++ b/features/magic-requires-in-cljc-files.feature
@@ -2,6 +2,7 @@
     Given I have a project "cljr" in "tmp"
     And I have a clojure-file "tmp/src/cljr/core.cljc"
     And I open file "tmp/src/cljr/core.cljc"
+    And the `cljr-slash-uses-suggest-libspec' flag is disabled
     And I clear the buffer
 
   Scenario: Does the right thing when facing clj reader conditionals

--- a/features/magic-requires.feature
+++ b/features/magic-requires.feature
@@ -4,6 +4,7 @@ Feature: Magic requires
     Given I have a project "cljr" in "tmp"
     And I have a clojure-file "tmp/src/cljr/core.clj"
     And I open file "tmp/src/cljr/core.clj"
+    And the `cljr-slash-uses-suggest-libspec' flag is disabled
     And I clear the buffer
 
   Scenario: Require is inserted automagically

--- a/features/step-definitions/clj-refactor-steps.el
+++ b/features/step-definitions/clj-refactor-steps.el
@@ -408,6 +408,11 @@
            (cljr--change-function-signature (list (cljr--plist-to-hash (cl-second cljr--test-occurrences)))
                                             cljr--baz-renamed-to-qux))))
 
+;; TODO: deprecate dependent tests after `cljr-slash-uses-suggest-libspec' is the only path.
+(Given "The `cljr-slash-uses-suggest-libspec' flag is disabled"
+       (lambda ()
+         (setq-local cljr-slash-uses-suggest-libspec nil)))
+
 (Given "The cache of namespace aliases is populated"
        (lambda ()
          (defun cljr--call-middleware-for-namespace-aliases ()


### PR DESCRIPTION
Also mark functions and defcustoms that will deprecate once suggest-libspec is the only path available, and expanded the documentation on the feature flag to provide context.

This is a step towards deprecating the old `cljr-slash` behavior provided by the `namespace-aliases` middleware started in #531 and implemented in #532. We have had this as an optional feature flag for over a year in total, so now we are trying to transition folks over to make it the default. Presuming no issues, we can then deprecate support for the old middleware.

~~As #530 is not complete, it's still not possible to specify language context in magic requires. However, even without that functionality, this implementation is a marked improvement over the old two stage prompt for language context, and then prompt for candidate requires.~~ #530 was addressed by https://github.com/clojure-emacs/refactor-nrepl/pull/392.

In the process of looking for future deprecations I also noted that `cljr-suggest-namespace-aliases` no longer appears to be an option we pass to the middleware. I *believe* we do this by default, but might be worth double checking before fully deprecating.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
