### PR TITLE
Expand cljr magic require namespaces documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* [#555](https://github.com/clojure-emacs/clj-refactor.el/pull/555): Document :only syntax for `cljr-magic-require-namespace` and improve default aliases.
+* [#555](https://github.com/clojure-emacs/clj-refactor.el/pull/555): expand default `cljr-magic-require-namespaces` aliases.
+* Handle an edge case for `cljr-slash`.
 
 ## 3.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#555](https://github.com/clojure-emacs/clj-refactor.el/pull/555): Document :only syntax for `cljr-magic-require-namespace` and improve default aliases.
+
 ## 3.11.0
 
 * [#554](https://github.com/clojure-emacs/clj-refactor.el/pull/554): Enable `cljr-slash-uses-suggest-libspec` by default.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -92,13 +92,16 @@ paths once this flag is removed."
 
 (defcustom cljr-magic-require-namespaces
   '(("edn"  . "clojure.edn")
-    ("io"   . "clojure.java.io")
+    ("io"     "clojure.java.io" :only ("clj"))
     ("math" . "clojure.math")
     ("set"  . "clojure.set")
     ("str"  . "clojure.string")
     ("walk" . "clojure.walk")
     ("zip"  . "clojure.zip"))
-  "Alist of aliases and namespaces used by `cljr-slash'."
+  "Alist of aliases to namespace libspec recommendations for `\\[cljr-slash]'.
+
+An optional keyword `:only` can limit a recommendation to the set of
+language contexts the libspec is available in."
   :type '(repeat (cons (string :tag "Short alias")
                        (string :tag "Full namespace")))
   :safe #'listp)

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -91,7 +91,8 @@ paths once this flag is removed."
   :safe #'booleanp)
 
 (defcustom cljr-magic-require-namespaces
-  '(("io"   . "clojure.java.io")
+  '(("edn"  . "clojure.edn")
+    ("io"   . "clojure.java.io")
     ("math" . "clojure.math")
     ("set"  . "clojure.set")
     ("str"  . "clojure.string")

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2107,8 +2107,13 @@ match. Returns a structure of (alias (ns1 ns2 ...))."
                (string-match-p (cljr--magic-requires-re) short))
       ;; This when-let might seem unnecessary but the regexp match
       ;; isn't perfect.
-      (when-let (long (cljr--aget cljr-magic-require-namespaces short))
-        (list short (list long))))))
+      (let ((long  (cljr--aget cljr-magic-require-namespaces short)))
+        (when-let (libspec (cond ((stringp long)
+                                  (list long))
+                                 ;; handle ("io" "clojure.java.io" :only ("clj"))
+                                 ((and (listp long) (stringp (car long)))
+                                  (list (car long)))))
+          (list short libspec))))))
 
 (defun cljr--in-keyword-sans-alias-p ()
   "Checks if thing at point is keyword without an alias."

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -101,7 +101,7 @@ paths once this flag is removed."
   "Alist of aliases to namespace libspec recommendations for `\\[cljr-slash]'.
 
 An optional keyword `:only` can limit a recommendation to the set of
-language contexts the libspec is available in."
+language contexts (clj, cljs) the libspec is available in."
   :type '(repeat (cons (string :tag "Short alias")
                        (string :tag "Full namespace")))
   :safe #'listp)


### PR DESCRIPTION
* Minimal documentation on the :only keyword.
* Backport support for `:only` in the `cljr-magic-requires-namespace` if the suggest-libspec flag is off
* Adds edn alias and limits io alias to clj only

Leverages https://github.com/clojure-emacs/refactor-nrepl/pull/392 and https://github.com/clojure-emacs/clj-refactor.el/issues/530.

Still needs more testing and expanded documentation but this seemed like a good incremental improvement.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s) 
  - not adding test coverage here as this is the deprecated path, but I did verify the parser change at the elisp repl.
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
