### PR TITLE
Pass :always-return-ns-form true to clean-ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `clean-ns` will reformat `ns` form even when no structural changes were made.
+
 ## 3.11.3
 
 - Fix incorrectly serialized values for `cljr-slash` when using `cljr-suggest-libspecs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-- `clean-ns` will reformat `ns` form even when no structural changes were made. This is useful when there are only whitespace changes which were previously discarded.
+## 3.12.0
+
+- `clean-ns` will now also reformat the `ns` form for whitespace-only changes, if needed.
+  - Previously, this wasn't possible since refactor-nrepl generally only works at the structural level.
+- Use refactor-nrepl [3.10.0](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.10.0/CHANGELOG.md#3100).
 
 ## 3.11.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- `clean-ns` will reformat `ns` form even when no structural changes were made.
+- `clean-ns` will reformat `ns` form even when no structural changes were made. This is useful when there are only whitespace changes which were previously discarded.
 
 ## 3.11.3
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Either in your project's `project.clj` or in the `:user`
 profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.9.1"]
+:plugins [[refactor-nrepl "3.10.0"]
           [cider/cider-nrepl "0.45.0"]]
 ```
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2970,6 +2970,7 @@ removed."
                        (cljr--create-msg "clean-ns"
                                          "path" path
                                          "relative-path" relative-path
+                                         "always-return-ns-form" "true"
                                          "libspec-whitelist" cljr-libspec-whitelist
                                          "print-right-margin" cljr-print-right-margin
                                          "print-miser-width" cljr-print-miser-width

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -7,7 +7,7 @@
 ;;         Lars Andersen <expez@expez.com>
 ;;         Benedek Fazekas <benedek.fazekas@gmail.com>
 ;;         Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 3.11.3
+;; Version: 3.12.0
 ;; Keywords: convenience, clojure, cider
 
 ;; Package-Requires: ((emacs "26.1") (seq "2.19") (yasnippet "0.6.1") (paredit "24") (multiple-cursors "1.2.2") (clojure-mode "5.18.0") (cider "1.11.1") (parseedn "1.2.0") (inflections "2.6") (hydra "0.13.2"))
@@ -3505,7 +3505,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-inline-symbol"
 ;; We used to derive the version out of `(cljr--version)`,
 ;; but now prefer a fixed version to fully decouple things and prevent unforeseen behavior.
 ;; This suits better our current pace of development.
-(defcustom cljr-injected-middleware-version "3.9.1"
+(defcustom cljr-injected-middleware-version "3.10.0"
   "The refactor-nrepl version to be injected.
 
 You can customize this in order to try out new releases.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2951,9 +2951,13 @@ in the namespace."
 (defun cljr--replace-ns (new-ns)
   (save-excursion
     (cljr--goto-ns)
-    (clojure-delete-and-extract-sexp)
-    (insert new-ns)
-    (cljr--just-one-blank-line)))
+    (let ((begin (point)))
+      (forward-sexp)
+      (let ((old-ns (buffer-substring begin (point))))
+        (when (not (string-equal old-ns (string-trim-right new-ns)))
+          (delete-region begin (point))
+          (insert new-ns)
+          (cljr--just-one-blank-line))))))
 
 (defun cljr--clean-ns (&optional path no-prune?)
   "If PATH is passed use, that instead of the path to the current buffer.


### PR DESCRIPTION
This allows for cleaning up whitespace even if there are no structural changes.

Note that I went with always replacing the ns form even if there were no whitespace changes because there's no function for *only* extracting the current ns form  for comparison (in other words: there's only `clojure-delete-and-extract-sexp` but no `clojure-extract-sexp`). It's probably fine!

Depends on https://github.com/clojure-emacs/refactor-nrepl/pull/407 and a corresponding update of `cljr-injected-middleware-version` once released.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
- [X] All tests are passing (run `./run-tests.sh`)
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
