### PR TITLE
use fallback for magic requires when there's no middlware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Introduce `cljr-magic-requires-fallback` defcustom to fallback magic requires to `cljr-magic-require-namespaces` if the middlware is not available.
+
 ## 3.12.0
 
 - `clean-ns` will now also reformat the `ns` form for whitespace-only changes, if needed.

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 (require 'paredit)
 (require 'clj-refactor)
 (require 'buttercup)
@@ -358,6 +359,21 @@
       (expect (cljr--prompt-or-select-libspec '("[a.a :as a]"))
               :to-equal "[a.a :as a]"))
     (expect 'completing-read :to-have-been-called-times 1)))
+
+(describe "cljr--magic-requires-libspec-defcustom"
+  (it "generates libspec for aliases from `cljr-magic-require-namespaces'"
+    (spy-on 'cljr--in-namespace-declaration-p :and-return-value nil)
+    (expect
+     (let ((cljr-magic-require-namespaces '(("foo" . "clojure.foo"))))
+       (cljr--magic-requires-libspec-defcustom "foo")
+       :to-equal "[clojure.foo :as foo]")))
+
+  (it "doesn't generate libspec when alias is unknown"
+    (spy-on 'cljr--in-namespace-declaration-p :and-return-value nil)
+    (expect
+     (let ((cljr-magic-require-namespaces '(("foo" . "clojure.foo"))))
+       (cljr--magic-requires-libspec-defcustom "bar")
+       :to-be nil))))
 
 (describe "cljr-slash"
   (it "inserts single selection from suggest-libspec"


### PR DESCRIPTION
added a new defcustom `cljr-magic-requires-fallback` defcustom, so we can generate require expressions (from `cljr-magic-require-namespaces`) even if middleware is not available for some reason (e.g. when using babashka)
- also, I updated `cljr-magic-require-namespaces` with more [idiomatic aliases from The Clojure Style Guide](https://guide.clojure.style/#use-idiomatic-namespace-aliases).

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `cask exec emacs -batch -Q -L . -eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" clj-refactor.el`)
      
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)


