### PR TITLE
Re-enable cljr-hotload-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Use CIDER 1.23's renamed nREPL API (`cider-nrepl-sync-request`, `cider-ensure-session`) when available, while staying compatible with older CIDER releases. Fixes byte-compilation warnings against recent CIDER.
+- Re-enable `cljr-hotload-dependency`, now that refactor-nrepl hotloads dependencies on top of `clojure.tools.deps` ([refactor-nrepl #231](https://github.com/clojure-emacs/refactor-nrepl/issues/231)). It also accepts `deps.edn`-style coordinate maps in addition to Leiningen vectors.
 - [Upgrade refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.11.0/CHANGELOG.md#3110).
 
 ## 3.12.0

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -124,7 +124,7 @@ These are called on all .clj files in the project."
   :type '(repeat string)
   :safe #'listp)
 
-(defcustom cljr-hotload-dependencies nil
+(defcustom cljr-hotload-dependencies t
   "If t, newly added dependencies are also hotloaded into the repl.
 This only applies to dependencies added by `cljr-add-project-dependency'."
   :type 'boolean
@@ -3230,6 +3230,22 @@ which is what nrepl backend expects for hot-loading."
                 (match-string-no-properties 4)
                 "]")))))
 
+(defun cljr--hotload-dependency-callback (response)
+  (cljr--maybe-rethrow-error response)
+  (cljr--post-command-message "Hotloaded %s" (nrepl-dict-get response "dependency")))
+
+(defun cljr--assert-dependency-vector (string)
+  (with-temp-buffer
+    (insert string)
+    (goto-char (point-min))
+    (cl-assert (cljr--looking-at-dependency-p) nil
+               (format
+                (concat "Expected dependency vector of type "
+                        "[org.clojure \"1.7.0\"] or "
+                        "org.clojure {:mvn/version \"1.7.0\"}, but got '%s'")
+                string)))
+  string)
+
 ;;;###autoload
 (defun cljr-hotload-dependency ()
   "Download a dependency (if needed) and hotload it into the current repl session.
@@ -3238,7 +3254,13 @@ Defaults to the dependency vector at point, but prompts if none is found.
 
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-hotload-dependency"
   (interactive)
-  (user-error "Temporarily disabled due to changes introduced with Java 9. See https://github.com/clojure-emacs/refactor-nrepl/pull/301"))
+  (cljr--ensure-op-supported "hotload-dependency")
+  (let ((dependency-vector (or (cljr--dependency-at-point)
+                               (cljr--prompt-user-for "Dependency vector: "))))
+    (cljr--assert-dependency-vector dependency-vector)
+    (cljr--call-middleware-async
+     (cljr--create-msg "hotload-dependency" "coordinates" dependency-vector)
+     #'cljr--hotload-dependency-callback)))
 
 (defun cljr--defn-str (&optional public)
   (if public


### PR DESCRIPTION
`cljr-hotload-dependency` was stubbed out as a `user-error` back in 2018, when the old Alembic-based middleware stopped working on Java 9/10. refactor-nrepl has since reimplemented hotloading on top of `clojure.tools.deps` (clojure-emacs/refactor-nrepl#231), so this restores the real implementation and flips `cljr-hotload-dependencies` back to its original default of `t`.

The backend now also accepts `deps.edn`-style coordinate maps in addition to Leiningen vectors.

Hard to cover with an automated test since it needs a live REPL with a `DynamicClassLoader`.

- [x] The commits are consistent with our contribution guidelines
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [ ] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)