### PR TITLE
Use CIDER 1.23's renamed nREPL API with a fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Use CIDER 1.23's renamed nREPL API (`cider-nrepl-sync-request`, `cider-ensure-session`) when available, while staying compatible with older CIDER releases. Fixes byte-compilation warnings against recent CIDER.
 - [Upgrade refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.11.0/CHANGELOG.md#3110).
 
 ## 3.12.0

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2352,12 +2352,26 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-sort-project-dep
         (indent-region (point-min) (point-max))
         (save-buffer)))))
 
+;; CIDER 1.23 renamed `cider-nrepl-send-sync-request' to
+;; `cider-nrepl-sync-request' and `cider-ensure-connected' to
+;; `cider-ensure-session'.  Prefer the modern names when they're available and
+;; fall back to the old ones, so we keep working with older CIDER releases.
+(defalias 'cljr--nrepl-sync-request
+  (if (fboundp 'cider-nrepl-sync-request)
+      'cider-nrepl-sync-request
+    'cider-nrepl-send-sync-request))
+
+(defalias 'cljr--ensure-session
+  (if (fboundp 'cider-ensure-session)
+      'cider-ensure-session
+    'cider-ensure-connected))
+
 (defun cljr--call-middleware-sync (request &optional key)
   "Call the middleware with REQUEST.
 
 If it's present KEY indicates the key to extract from the response."
   (let* ((nrepl-sync-request-timeout (if cljr-warn-on-eval nil 25))
-         (response (thread-first request cider-nrepl-send-sync-request cljr--maybe-rethrow-error)))
+         (response (thread-first request cljr--nrepl-sync-request cljr--maybe-rethrow-error)))
     (if key
         (nrepl-dict-get response key)
       response)))
@@ -3595,8 +3609,10 @@ warning by customizing `cljr-suppress-no-project-warning'.)"))))
 
 (defun cljr--ns-path (ns-name)
   "Find the file path to the ns named NS-NAME."
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "ns-path")
+  (cljr--ensure-session)
+  ;; No explicit op-support check: `cider-sync-request:ns-path' sends the
+  ;; namespaced `cider/ns-path' op, whose support modern CIDER enforces in the
+  ;; nREPL sender automatically.
   (cljr--chop-prefix "file:"
                      (cider-sync-request:ns-path ns-name)))
 


### PR DESCRIPTION
CIDER 1.23 deprecated `cider-nrepl-send-sync-request` (now `cider-nrepl-sync-request`) and `cider-ensure-connected` (now `cider-ensure-session`), which has been turning our byte-compilation red against recent CIDER (CI compiles against melpa-unstable with `--warnings-as-errors`).

Rather than bump the hard requirement to the still-unreleased 1.23, this aliases to the modern names when they're available and falls back to the old ones, so we keep working with older CIDER too.

Also drops the explicit `cider-ensure-op-supported` check in `cljr--ns-path`: it was checking the bare `"ns-path"` op while the request actually sends the namespaced `"cider/ns-path"`, whose support modern CIDER enforces in the nREPL sender automatically.

Compile is green again (`--warnings-as-errors`), lint is clean, and all 57 buttercup specs pass.

- [x] The commits are consistent with our contribution guidelines
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)