### PR TITLE
Remove the long-obsolete 2.3.0-era aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **(Breaking)** Remove the `cljr-thread`, `cljr-thread-first-all`, `cljr-thread-last-all`, `cljr-unwind`, `cljr-unwind-all`, `cljr-cycle-privacy`, `cljr-cycle-if`, `cljr-cycle-coll`, `cljr-thread-all-but-last`, `cljr-use-metadata-for-privacy` and `cljr-find-usages-ignore-analyzer-errors` aliases, all deprecated back in 2.3.0. Use the `clojure-*` equivalents (now in clojure-mode) and `cljr-ignore-analyzer-errors`.
 - Use CIDER 1.23's renamed nREPL API (`cider-nrepl-sync-request`, `cider-ensure-session`) when available, while staying compatible with older CIDER releases. Fixes byte-compilation warnings against recent CIDER.
 - Re-enable `cljr-hotload-dependency`, now that refactor-nrepl hotloads dependencies on top of `clojure.tools.deps` ([refactor-nrepl #231](https://github.com/clojure-emacs/refactor-nrepl/issues/231)). It also accepts `deps.edn`-style coordinate maps in addition to Leiningen vectors.
 - [Upgrade refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl/blob/v3.11.0/CHANGELOG.md#3110).

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -193,8 +193,6 @@ will not work as expected in such REPLs."
   :type 'boolean
   :safe #'booleanp)
 
-(define-obsolete-variable-alias 'cljr-find-usages-ignore-analyzer-errors 'cljr-ignore-analyzer-errors "2.3.0")
-
 (defcustom cljr-ignore-analyzer-errors nil
   "If t, `cljr-find-usages' `cljr-inline-symbol' `cljr-rename-symbol' ignores namespaces that cannot be analyzed.
 If any namespaces presents an analyzer error, it is skipped and
@@ -4453,19 +4451,6 @@ If injecting the dependencies is not preferred set
   '(cljr--inject-jack-in-dependencies))
 
 (add-hook 'cider-connected-hook #'cljr--init-middleware)
-
-;; moved to Clojure mode, made obsolete here
-(define-obsolete-variable-alias 'cljr-thread-all-but-last 'clojure-thread-all-but-last "2.3.0")
-(define-obsolete-variable-alias 'cljr-use-metadata-for-privacy 'clojure-use-metadata-for-privacy "2.3.0")
-
-(define-obsolete-function-alias 'cljr-thread 'clojure-thread "2.3.0")
-(define-obsolete-function-alias 'cljr-thread-first-all 'clojure-thread-first-all "2.3.0")
-(define-obsolete-function-alias 'cljr-thread-last-all 'clojure-thread-last-all "2.3.0")
-(define-obsolete-function-alias 'cljr-unwind 'clojure-unwind "2.3.0")
-(define-obsolete-function-alias 'cljr-unwind-all 'clojure-unwind-all "2.3.0")
-(define-obsolete-function-alias 'cljr-cycle-privacy 'clojure-cycle-privacy "2.3.0")
-(define-obsolete-function-alias 'cljr-cycle-if 'clojure-cycle-if "2.3.0")
-(make-obsolete 'cljr-cycle-coll "reworked into convert collection to list, quoted list, map, vector, set in Clojure mode." "2.3.0")
 
 ;; ------ minor mode -----------
 ;;;###autoload


### PR DESCRIPTION
The threading and cycling refactorings moved into clojure-mode years ago, and the `cljr-` aliases pointing at them have been carrying obsolescence warnings since 2.3.0. At this point they're just dead surface, so this drops them:

- `cljr-thread`, `cljr-thread-first-all`, `cljr-thread-last-all`
- `cljr-unwind`, `cljr-unwind-all`
- `cljr-cycle-privacy`, `cljr-cycle-if`, `cljr-cycle-coll`
- the `cljr-thread-all-but-last` and `cljr-use-metadata-for-privacy` variable aliases
- the `cljr-find-usages-ignore-analyzer-errors` variable alias

Users should call the `clojure-*` commands directly (the keymap already binds those), or `cljr-ignore-analyzer-errors` for the variable. This is technically breaking, so it's probably best held for a major version bump.

Nothing in the codebase referenced these anymore; all 57 buttercup specs still pass.

- [x] The commits are consistent with our contribution guidelines
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `./run-tests.sh`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)