### PR TITLE
Pin the setup-emacs action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jcs090218/setup-emacs@master
+      - uses: jcs090218/setup-emacs@v3
         with:
           version: ${{ matrix.emacs-version }}
 


### PR DESCRIPTION
Track a released tag instead of `master`, matching what CIDER does - keeps CI reproducible and avoids surprise changes from the action's master branch.

(Context: this started as an attempt to fix the intermittent `HTTP 429` from the Emacs setup step, but that turns out to be transient external flakiness in nix-emacs-ci's channel resolution that a token can't fix. Leaving that for a manual rerun when it happens.)