### PR TITLE
Pre-4.0 tidy: dead code + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Either in your project's `project.clj` or in the `:user`
 profile found at `~/.lein/profiles.clj`:
 
 ```clojure
-:plugins [[refactor-nrepl "3.10.0"]
-          [cider/cider-nrepl "0.45.0"]]
+:plugins [[refactor-nrepl "3.14.0"]
+          [cider/cider-nrepl "0.61.0"]]
 ```
 
 Check out the much longer
@@ -74,6 +74,9 @@ clj-refactor | refactor-nrepl | CIDER       | Clojure | Java |
 2.4.0        |  2.4.0         | 0.17, 0.18  | 1.7+    | 8+   |
 2.5.0        |  2.5.0         | 0.24        | 1.8+    | 8+   |
 3.0.0+       |  3.0.0+        | 1.0         | 1.9+    | 11+  |
+4.0.0+       |  3.x           | 1.11+       | 1.10+   | 8+   |
+
+clj-refactor 4.0.0+ requires Emacs 28.1 or newer.
 
 ### Middleware
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -628,8 +628,6 @@ if the point is currently placed at the opening parentheses of an anonymous func
           (when (<= (point) search-bound)
             (error "Can't find definition of anonymous function")))))))
 
-(defalias 'cljr--evenp #'cl-evenp)
-
 (defun cljr--remove-tramp-prefix-from-msg (entry)
   (let* ((k (car entry))
          (v (cadr entry)))
@@ -645,7 +643,7 @@ if the point is currently placed at the opening parentheses of an anonymous func
   "Create a msg for the middleware for OP and optionally include the kv pairs KVS.
 
 All config settings are included in the created msg."
-  (cl-assert (cljr--evenp (length kvs)) nil "Can't create msg to send to the middleware.\
+  (cl-assert (cl-evenp (length kvs)) nil "Can't create msg to send to the middleware.\
   Received an uneven number of kv pairs: %s " kvs)
   (apply #'list
          "op" op
@@ -2578,7 +2576,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-promote-function
                             "ignore-paths" cljr-middleware-ignored-paths
                             "ignore-errors"
                             (when cljr-ignore-analyzer-errors "true"))))
-    (with-current-buffer (with-no-warnings (cider-current-repl))
+    (with-current-buffer (cider-current-repl)
       (setq cljr--occurrence-count 0)
       (setq cljr--num-syms -1)
       (setq cljr--occurrence-ids '()))
@@ -2985,7 +2983,7 @@ Date. -> Date
   (let ((request (cljr--create-msg "resolve-missing"
                                    "symbol" symbol
                                    "session"
-                                   (with-no-warnings (cider-nrepl-eval-session)))))
+                                   (cider-nrepl-eval-session))))
     (when ns
       (setq request (append request (list "ns" ns))))
     (when-let* ((candidates (thread-first request
@@ -3345,7 +3343,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-inline-symbol"
   "Extract the package version from its package metadata."
   (package-get-version))
 
-(defun cljr--version (&optional _for-compat)
+(defun cljr--version ()
   "Retrieve the version."
   (if (string-match-p "-snapshot" cljr-version)
       (let ((pkg-version (cljr--pkg-version)))
@@ -4299,8 +4297,8 @@ If injecting the dependencies is not preferred set
                                                     :predicate cljr--inject-middleware-p))))
 
 ;;;###autoload
-(eval-after-load 'cider
-  '(cljr--inject-jack-in-dependencies))
+(with-eval-after-load 'cider
+  (cljr--inject-jack-in-dependencies))
 
 (add-hook 'cider-connected-hook #'cljr--init-middleware)
 


### PR DESCRIPTION
Two small pre-4.0 cleanups.

**Dead code**
- Inline `cl-evenp` and drop the pointless `cljr--evenp` alias.
- Remove the dead `&optional _for-compat` arg from `cljr--version` (no caller passes it).
- Switch `eval-after-load` + quoted form to `with-eval-after-load`.
- Drop two stale `with-no-warnings` wrappers around `cider-current-repl` and `cider-nrepl-eval-session` - both are current, defined CIDER functions, so compiling stays clean with `--warnings-as-errors`.

**README**
- Bump the example `refactor-nrepl`/`cider-nrepl` plugin versions (they were on 3.10.0 / 0.45.0; now 3.14.0 / 0.61.0).
- Add a compatibility-table row for the 4.0 line and a note about the Emacs 28.1+ requirement.

Compile clean (`--warnings-as-errors`), buttercup green.

- [x] The commits are consistent with our contribution guidelines
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)