### PR TITLE
Add a transient menu for the command surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+- Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.
 - **(Breaking)** Drop the `multiple-cursors`, `hydra` and `inflections` dependencies.
-  - The hydra menus (`C-c C-m h*`) are gone; use the regular keybindings (e.g. via `which-key`) for discovery.
+  - The hydra menus are replaced by the new `clj-refactor-menu` transient (see above).
   - The `multiple-cursors` integration is gone; let/extract/promote refactorings now always prompt for names. The `cljr-use-multiple-cursors` option is removed.
   - Parameter-name guessing in `cljr-create-fn-from-example` now uses a small built-in inflector instead of `inflections`.
 - **(Breaking)** Remove the `cljr-thread`, `cljr-thread-first-all`, `cljr-thread-last-all`, `cljr-unwind`, `cljr-unwind-all`, `cljr-cycle-privacy`, `cljr-cycle-if`, `cljr-cycle-coll`, `cljr-thread-all-but-last`, `cljr-use-metadata-for-privacy` and `cljr-find-usages-ignore-analyzer-errors` aliases, all deprecated back in 2.3.0. Use the `clojure-*` equivalents (now in clojure-mode) and `cljr-ignore-analyzer-errors`.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ All functions in `clj-refactor` have a two-letter mnemonic
 shortcut. E.g. `rs` for `cljr-rename-symbol`.  Given the prefix choice
 in the example setup you'd call this function by hitting `C-c C-m rs`
 
+If you can't remember a shortcut, run `M-x clj-refactor-menu` (or hit `hh`
+under your prefix, e.g. `C-c C-m hh`) for a [transient](https://github.com/magit/transient)
+menu of every command grouped by category. It shows the keys as you go, so
+it doubles as a way to learn them, and its Options section toggles common
+settings for the current session.
+
 See the wiki for a complete [list of available refactorings](https://github.com/clojure-emacs/clj-refactor.el/wiki),
 demonstrations and customization points.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -10,7 +10,7 @@
 ;; Version: 3.12.0
 ;; Keywords: convenience, clojure, cider
 
-;; Package-Requires: ((emacs "28.1") (yasnippet "0.6.1") (paredit "24") (clojure-mode "5.18.0") (cider "1.11.1") (parseedn "1.2.0"))
+;; Package-Requires: ((emacs "28.1") (yasnippet "0.6.1") (paredit "24") (clojure-mode "5.18.0") (cider "1.11.1") (parseedn "1.2.0") (transient "0.4.1"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -39,6 +39,7 @@
 (require 'cider)
 (require 'parseedn)
 (require 'sgml-mode)
+(require 'transient)
 (require 'subword)
 
 (defgroup cljr nil
@@ -394,6 +395,7 @@ Otherwise open the file and do the changes non-interactively."
     ("up" . (cljr-update-project-dependencies "Update project dependencies" ?U ("project")))
     ("uw" . (clojure-unwind "Unwind" ?w ("code")))
     ("ad" . (cljr-add-declaration "Add declaration" ?d ("toplevel-form")))
+    ("hh" . (clj-refactor-menu "Menu of refactorings" ?h ("cljr")))
     ("?" . (cljr-describe-refactoring "Describe refactoring" ?d ("cljr")))))
 
 (defun cljr--add-keybindings (key-fn)
@@ -412,6 +414,117 @@ Otherwise open the file and do the changes non-interactively."
 (defun cljr-add-keybindings-with-modifier (modifier)
   "Bind keys in `cljr--all-helpers' under a MODIFIER key."
   (cljr--add-keybindings (apply-partially 'cljr--key-pairs-with-modifier modifier)))
+
+
+;; ------ transient menu -----------
+
+(defun cljr--menu-toggle-description (label enabled)
+  "Format the transient toggle LABEL, showing whether it is ENABLED."
+  (format "%s %s" (if enabled "[X]" "[ ]") label))
+
+(transient-define-suffix cljr--toggle-warn-on-eval ()
+  "Toggle `cljr-warn-on-eval' from the menu."
+  :transient t
+  :description (lambda ()
+                 (cljr--menu-toggle-description "Warn before evaluating code"
+                                                cljr-warn-on-eval))
+  (interactive)
+  (setq cljr-warn-on-eval (not cljr-warn-on-eval)))
+
+(transient-define-suffix cljr--toggle-auto-clean-ns ()
+  "Toggle `cljr-auto-clean-ns' from the menu."
+  :transient t
+  :description (lambda ()
+                 (cljr--menu-toggle-description "Auto clean-ns after ns changes"
+                                                cljr-auto-clean-ns))
+  (interactive)
+  (setq cljr-auto-clean-ns (not cljr-auto-clean-ns)))
+
+(transient-define-suffix cljr--toggle-favor-private-functions ()
+  "Toggle `cljr-favor-private-functions' from the menu."
+  :transient t
+  :description (lambda ()
+                 (cljr--menu-toggle-description "Favor private functions"
+                                                cljr-favor-private-functions))
+  (interactive)
+  (setq cljr-favor-private-functions (not cljr-favor-private-functions)))
+
+(transient-define-suffix cljr--toggle-hotload-dependencies ()
+  "Toggle `cljr-hotload-dependencies' from the menu."
+  :transient t
+  :description (lambda ()
+                 (cljr--menu-toggle-description "Hotload added dependencies"
+                                                cljr-hotload-dependencies))
+  (interactive)
+  (setq cljr-hotload-dependencies (not cljr-hotload-dependencies)))
+
+(transient-define-suffix cljr--toggle-ignore-analyzer-errors ()
+  "Toggle `cljr-ignore-analyzer-errors' from the menu."
+  :transient t
+  :description (lambda ()
+                 (cljr--menu-toggle-description "Ignore analyzer errors"
+                                                cljr-ignore-analyzer-errors))
+  (interactive)
+  (setq cljr-ignore-analyzer-errors (not cljr-ignore-analyzer-errors)))
+
+;;;###autoload (autoload 'clj-refactor-menu "clj-refactor" nil t)
+(transient-define-prefix clj-refactor-menu ()
+  "A transient menu of clj-refactor commands, grouped by category.
+
+The entries mirror the two-letter keybindings, so the menu doubles as a
+way to learn them.  The Options section toggles common settings for the
+current session."
+  [["Namespace"
+    ("ai" "Add import to ns" cljr-add-import-to-ns)
+    ("am" "Add missing libspec" cljr-add-missing-libspec)
+    ("ar" "Add require to ns" cljr-add-require-to-ns)
+    ("au" "Add use to ns" cljr-add-use-to-ns)
+    ("cn" "Clean ns" cljr-clean-ns)
+    ("rm" "Require macro" cljr-require-macro)
+    ("sr" "Stop referring" cljr-stop-referring)
+    ("ap" "Add project dependency" cljr-add-project-dependency)]
+   ["Code"
+    ("ci" "Cycle if" clojure-cycle-if)
+    ("ct" "Cycle thread" cljr-cycle-thread)
+    ("dk" "Destructure keys" cljr-destructure-keys)
+    ("il" "Introduce let" cljr-introduce-let)
+    ("el" "Expand let" cljr-expand-let)
+    ("ml" "Move to let" cljr-move-to-let)
+    ("rl" "Remove let" cljr-remove-let)
+    ("pf" "Promote function" cljr-promote-function)
+    ("tf" "Thread first all" clojure-thread-first-all)
+    ("th" "Thread" clojure-thread)
+    ("tl" "Thread last all" clojure-thread-last-all)
+    ("ua" "Unwind all" clojure-unwind-all)
+    ("uw" "Unwind" clojure-unwind)]
+   ["Top-level form"
+    ("ad" "Add declaration" cljr-add-declaration)
+    ("as" "Add stubs for interface/protocol" cljr-add-stubs)
+    ("cp" "Cycle privacy" clojure-cycle-privacy)
+    ("cs" "Change function signature" cljr-change-function-signature)
+    ("ec" "Extract constant" cljr-extract-constant)
+    ("ed" "Extract form as def" cljr-extract-def)
+    ("ef" "Extract function" cljr-extract-function)
+    ("fe" "Create function from example" cljr-create-fn-from-example)
+    ("mf" "Move form" cljr-move-form)]]
+  [["Project"
+    ("fu" "Find usages" cljr-find-usages)
+    ("rs" "Rename symbol" cljr-rename-symbol)
+    ("rf" "Rename file-or-dir" cljr-rename-file-or-dir)
+    ("is" "Inline symbol" cljr-inline-symbol)
+    ("pc" "Project clean" cljr-project-clean)
+    ("hd" "Hotload dependency" cljr-hotload-dependency)
+    ("sp" "Sort project dependencies" cljr-sort-project-dependencies)
+    ("up" "Update project dependencies" cljr-update-project-dependencies)]
+   ["clj-refactor"
+    ("sc" "Show the changelog" cljr-show-changelog)
+    ("?" "Describe refactoring" cljr-describe-refactoring)]
+   ["Options"
+    ("W" cljr--toggle-warn-on-eval)
+    ("N" cljr--toggle-auto-clean-ns)
+    ("P" cljr--toggle-favor-private-functions)
+    ("H" cljr--toggle-hotload-dependencies)
+    ("E" cljr--toggle-ignore-analyzer-errors)]])
 
 
 ;; ------ utilities -----------

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -409,3 +409,18 @@ ex/"))))
                                            2))))
         (setq-local tramp-mode nil) ;; prevent hanging
         (expect v :to-equal '("file" "a.clj" "something" "else"))))))
+
+(describe "clj-refactor-menu"
+  (it "is a transient prefix"
+    (expect (get 'clj-refactor-menu 'transient--prefix) :not :to-be nil))
+  (it "exposes every command from `cljr--all-helpers' under its own key"
+    ;; Guards against adding a command to `cljr--all-helpers' but forgetting
+    ;; to list it in the transient menu.
+    (dolist (entry cljr--all-helpers)
+      (let ((key (car entry))
+            (command (cadr entry)))
+        ;; The menu itself is bound in `cljr--all-helpers' but is the entry
+        ;; point, so it isn't one of the menu's own suffixes.
+        (unless (eq command 'clj-refactor-menu)
+          (let ((suffix (ignore-errors (transient-get-suffix 'clj-refactor-menu key))))
+            (expect suffix :not :to-be nil)))))))


### PR DESCRIPTION
Restores the discoverability the hydra menus used to provide - using a built-in `transient` (no new hard dependency beyond what CIDER already pulls in) instead of the dropped `hydra`.

`M-x clj-refactor-menu` (bound to `hh` under your prefix, e.g. `C-c C-m hh` - the old hydra key) opens a menu of every command grouped by category (Namespace / Code / Top-level form / Project), keyed by the same two-letter mnemonics as the keybindings, so it doubles as a way to learn them. An **Options** section toggles the most common settings for the session (`warn-on-eval`, `auto-clean-ns`, `favor-private-functions`, `hotload-dependencies`, `ignore-analyzer-errors`).

Inspired by CIDER's recent transient-menu work (#4048).

A drift test asserts every command in `cljr--all-helpers` is reachable in the menu, so they can't fall out of sync.

Compile clean (`--warnings-as-errors`), lint clean, 59 buttercup specs pass.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)