### PR TITLE
Responsiveness quick wins (buffer leaks, project-clean progress, artifact caching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.
+- Performance: project-wide refactorings (rename symbol, inline symbol, change function signature) no longer leave behind buffers they had to open, which previously slowed Emacs down on large renames.
+- `cljr-project-clean` now shows a progress reporter instead of freezing Emacs silently.
+- Performance: cache the artifact and version lists fetched by the dependency commands, so they aren't re-requested on every invocation. The TTL is configurable via `cljr-artifact-cache-ttl` (default 300s; set to nil to disable).
 - **(Breaking)** Drop the `multiple-cursors`, `hydra` and `inflections` dependencies.
   - The hydra menus are replaced by the new `clj-refactor-menu` transient (see above).
   - The `multiple-cursors` integration is gone; let/extract/promote refactorings now always prompt for names. The `cljr-use-multiple-cursors` option is removed.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -330,6 +330,35 @@ Otherwise open the file and do the changes non-interactively."
            ;; Don't accumulate open buffers, since this can slow down Emacs for large projects:
            (kill-buffer))))))
 
+(defvar cljr--opened-buffers 'unset
+  "Collector for buffers opened during a project-wide operation.
+Bound to a list by `cljr--with-opened-buffers'; otherwise the symbol
+`unset', which means `cljr--find-file-noselect' does not record anything.")
+
+(defun cljr--find-file-noselect (file)
+  "Like `find-file-noselect' for FILE, but track newly-opened buffers.
+When called within `cljr--with-opened-buffers', a buffer opened here for a
+file that wasn't already being visited is collected so the wrapper can
+kill it afterwards.  This avoids the buffer accumulation that slows Emacs
+down on large project-wide refactorings (rename, inline, change
+signature)."
+  (let ((already (get-file-buffer file))
+        (buffer (find-file-noselect file)))
+    (when (and (null already) (listp cljr--opened-buffers))
+      (push buffer cljr--opened-buffers))
+    buffer))
+
+(defmacro cljr--with-opened-buffers (&rest body)
+  "Run BODY, then kill any file buffers it opened via `cljr--find-file-noselect'.
+Buffers that were already being visited before BODY ran are left alone."
+  (declare (indent 0) (debug (body)))
+  `(let ((cljr--opened-buffers nil))
+     (unwind-protect
+         (progn ,@body)
+       (dolist (buffer cljr--opened-buffers)
+         (when (buffer-live-p buffer)
+           (kill-buffer buffer))))))
+
 (define-key clj-refactor-map [remap paredit-raise-sexp] 'cljr-raise-sexp)
 (define-key clj-refactor-map [remap paredit-splice-sexp-killing-backward] 'cljr-splice-sexp-killing-backward)
 (define-key clj-refactor-map [remap paredit-splice-sexp-killing-forward] 'cljr-splice-sexp-killing-forward)
@@ -2172,12 +2201,18 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-project-clean"
   (interactive)
   (when (or (not cljr-project-clean-prompt)
             (yes-or-no-p "Cleaning your project might change many of your clj files. Do you want to proceed?"))
-    (let ((*cljr--noninteractive* t))
-      (dolist (filename (cljr--project-files))
-        (when (and (cljr--clojure-filename-p filename)
-                   (not (cljr--excluded-from-project-clean-p filename)))
-          (cljr--update-file filename
-            (ignore-errors (seq-map 'funcall cljr-project-clean-functions))))))
+    (let* ((*cljr--noninteractive* t)
+           (files (seq-filter (lambda (filename)
+                                (and (cljr--clojure-filename-p filename)
+                                     (not (cljr--excluded-from-project-clean-p filename))))
+                              (cljr--project-files)))
+           (reporter (make-progress-reporter "Cleaning project..." 0 (max 1 (length files))))
+           (i 0))
+      (dolist (filename files)
+        (cljr--update-file filename
+          (ignore-errors (seq-map 'funcall cljr-project-clean-functions)))
+        (progress-reporter-update reporter (setq i (1+ i)) filename))
+      (progress-reporter-done reporter))
     (if (and (cider-connected-p) (not cljr-warn-on-eval) (cljr--op-supported-p "warm-ast-cache"))
         (cljr--warm-ast-cache))
     (cljr--post-command-message "Project clean done.")))
@@ -2325,13 +2360,42 @@ If it's present KEY indicates the key to extract from the response."
 (defun cljr--call-middleware-async (request &optional callback)
   (cider-nrepl-send-request request callback))
 
+(defcustom cljr-artifact-cache-ttl 300
+  "Number of seconds to cache artifact and version lists on the Emacs side.
+
+The dependency commands (`cljr-add-project-dependency' and friends) fetch
+the list of available artifacts, and the versions of a given artifact,
+from the middleware.  Those lists change rarely, so they are cached for
+this many seconds to avoid a round-trip on every invocation.  Set to nil
+to disable the cache."
+  :type '(choice (const :tag "Disable" nil) integer)
+  :package-version '(clj-refactor . "4.0.0")
+  :safe (lambda (x) (or (null x) (integerp x))))
+
+;; Each cache entry is a cons of (timestamp . value).
+(defvar cljr--artifacts-cache nil
+  "Cached artifact list, as a cons of (timestamp . artifacts).")
+
+(defvar cljr--versions-cache (make-hash-table :test #'equal)
+  "Per-artifact version cache, mapping artifact to (timestamp . versions).")
+
+(defun cljr--cache-fresh-p (entry)
+  "Return non-nil if cache ENTRY is present and within `cljr-artifact-cache-ttl'."
+  (and cljr-artifact-cache-ttl
+       entry
+       (< (- (float-time) (car entry)) cljr-artifact-cache-ttl)))
+
 (defun cljr--get-artifacts-from-middleware (force)
-  (message "Retrieving list of available libraries...")
-  (let* ((request (cljr--create-msg "artifact-list" "force" (if force "true" "false")))
-         (artifacts (cljr--call-middleware-sync request "artifacts")))
-    (if artifacts
-        artifacts
-      (user-error "Empty artifact list received from middleware"))))
+  (if (and (not force) (cljr--cache-fresh-p cljr--artifacts-cache))
+      (cdr cljr--artifacts-cache)
+    (message "Retrieving list of available libraries...")
+    (let* ((request (cljr--create-msg "artifact-list" "force" (if force "true" "false")))
+           (artifacts (cljr--call-middleware-sync request "artifacts")))
+      (if artifacts
+          (progn
+            (setq cljr--artifacts-cache (cons (float-time) artifacts))
+            artifacts)
+        (user-error "Empty artifact list received from middleware")))))
 
 (defun cljr--update-artifact-cache ()
   (cljr--call-middleware-async (cljr--create-msg "artifact-list"
@@ -2396,11 +2460,16 @@ before non-empty. This lets 1.7.0 be sorted above 1.7.0-RC1."
       (reverse res))))
 
 (defun cljr--get-versions-from-middleware (artifact)
-  (let* ((request (cljr--create-msg "artifact-versions" "artifact" artifact))
-         (versions (nreverse (sort (cljr--call-middleware-sync request "versions") 'cljr--dictionary-lessp))))
-    (if versions
-        versions
-      (error "Empty version list received from middleware"))))
+  (let ((cached (gethash artifact cljr--versions-cache)))
+    (if (cljr--cache-fresh-p cached)
+        (cdr cached)
+      (let* ((request (cljr--create-msg "artifact-versions" "artifact" artifact))
+             (versions (nreverse (sort (cljr--call-middleware-sync request "versions") 'cljr--dictionary-lessp))))
+        (if versions
+            (progn
+              (puthash artifact (cons (float-time) versions) cljr--versions-cache)
+              versions)
+          (error "Empty version list received from middleware"))))))
 
 (defun cljr--prompt-user-for (prompt &optional choices)
   "Prompt the user with PROMPT.
@@ -2792,7 +2861,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-find-usages"
 (defun cljr--rename-occurrence (file line-beg col-beg line-end col-end name new-name)
   (save-excursion
     (with-current-buffer
-        (find-file-noselect file)
+        (cljr--find-file-noselect file)
       (let* ((name (thread-last name cljr--symbol-suffix regexp-quote))
              (search-limit (save-excursion
                              (progn
@@ -2813,17 +2882,18 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-find-usages"
       (save-buffer))))
 
 (defun cljr--rename-occurrences (occurrences new-name)
-  (dolist (symbol-meta occurrences)
-    (let* ((file (cljr--get-valid-filename symbol-meta))
-           (line-beg (gethash :line-beg symbol-meta))
-           (col-beg (gethash :col-beg symbol-meta))
-           (line-end (gethash :line-end symbol-meta))
-           (col-end (gethash :col-end symbol-meta))
-           (name (gethash :name symbol-meta))
-           (new-name* (if (stringp new-name)
-                          new-name
-                        (funcall new-name name))))
-      (cljr--rename-occurrence file line-beg col-beg line-end col-end name new-name*))))
+  (cljr--with-opened-buffers
+    (dolist (symbol-meta occurrences)
+      (let* ((file (cljr--get-valid-filename symbol-meta))
+             (line-beg (gethash :line-beg symbol-meta))
+             (col-beg (gethash :col-beg symbol-meta))
+             (line-end (gethash :line-end symbol-meta))
+             (col-end (gethash :col-end symbol-meta))
+             (name (gethash :name symbol-meta))
+             (new-name* (if (stringp new-name)
+                            new-name
+                          (funcall new-name name))))
+        (cljr--rename-occurrence file line-beg col-beg line-end col-end name new-name*)))))
 
 ;;;###autoload
 (defun cljr-rename-symbol (&optional new-name)
@@ -3309,7 +3379,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-stubs"
   (let ((file (cljr--get-valid-filename definition))
         (line-beg (gethash :line-beg definition))
         (col-beg (gethash :col-beg definition)))
-    (with-current-buffer (find-file-noselect file)
+    (with-current-buffer (cljr--find-file-noselect file)
       (goto-char (point-min))
       (forward-line (1- line-beg))
       (forward-char (1- col-beg))
@@ -3367,28 +3437,29 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-stubs"
     (insert def)))
 
 (defun cljr--inline-symbol (definition occurrences)
-  (let* ((def (gethash :definition definition))
-         (inline-fn-p (string-prefix-p "(fn" def)))
-    (dolist (symbol-meta (cljr--sort-occurrences occurrences))
-      (let* ((file (cljr--get-valid-filename symbol-meta))
-             (line-beg (gethash :line-beg symbol-meta))
-             (col-beg (gethash :col-beg symbol-meta)))
-        (with-current-buffer (find-file-noselect file)
-          (goto-char (point-min))
-          (forward-line (1- line-beg))
-          (forward-char (1- col-beg))
-          (let* ((call-site-p (and inline-fn-p
-                                   (looking-back "(\s*" (line-beginning-position))))
-                 (sexp (if call-site-p
-                           (prog1 (cljr--extract-sexp-as-list)
-                             (paredit-backward-up)
-                             (clojure-delete-and-extract-sexp))
-                         (clojure-delete-and-extract-sexp))))
-            (if call-site-p
-                (cljr--inline-fn-at-call-site def sexp)
-              (insert def)))))))
-  (save-buffer)
-  (cljr--delete-definition definition))
+  (cljr--with-opened-buffers
+    (let* ((def (gethash :definition definition))
+           (inline-fn-p (string-prefix-p "(fn" def)))
+      (dolist (symbol-meta (cljr--sort-occurrences occurrences))
+        (let* ((file (cljr--get-valid-filename symbol-meta))
+               (line-beg (gethash :line-beg symbol-meta))
+               (col-beg (gethash :col-beg symbol-meta)))
+          (with-current-buffer (cljr--find-file-noselect file)
+            (goto-char (point-min))
+            (forward-line (1- line-beg))
+            (forward-char (1- col-beg))
+            (let* ((call-site-p (and inline-fn-p
+                                     (looking-back "(\s*" (line-beginning-position))))
+                   (sexp (if call-site-p
+                             (prog1 (cljr--extract-sexp-as-list)
+                               (paredit-backward-up)
+                               (clojure-delete-and-extract-sexp))
+                           (clojure-delete-and-extract-sexp))))
+              (if call-site-p
+                  (cljr--inline-fn-at-call-site def sexp)
+                (insert def)))))))
+    (save-buffer)
+    (cljr--delete-definition definition)))
 
 (defun cljr--var-info (&optional symbol all)
   "Like `cider-var-info' but also handles locally bound vars.
@@ -4297,28 +4368,29 @@ Point is assumed to be at the function being called."
   ;; Indexing is from 0
   ;; The OCCURRENCES are the same as those returned by `cljr--find-symbol'
   (let ((*cljr--noninteractive* t))
-    (dolist (symbol-meta occurrences)
-      (let ((file (cljr--get-valid-filename symbol-meta))
-            (line-beg (gethash :line-beg symbol-meta))
-            (col-beg (gethash :col-beg symbol-meta))
-            (name (gethash :name symbol-meta))
-            (match (gethash :match symbol-meta)))
-        (with-current-buffer
-            (find-file-noselect file)
-          (goto-char (point-min))
-          (forward-line (1- line-beg))
-          (move-to-column (1- col-beg))
-          (cond
-           ((cljr--ignorable-occurrence-p) :do-nothing)
-           ((cljr--call-site-p name) (cljr--update-call-site signature-changes))
-           ((cljr--partial-call-site-p)
-            (cljr--update-partial-call-site signature-changes))
-           ((cljr--apply-call-site-p)
-            (cljr--update-apply-call-site signature-changes))
-           ((cljr--defnp match)
-            (cljr--update-function-signature signature-changes))
-           (t (cljr--append-to-manual-intervention-buffer)))
-          (save-buffer)))))
+    (cljr--with-opened-buffers
+      (dolist (symbol-meta occurrences)
+        (let ((file (cljr--get-valid-filename symbol-meta))
+              (line-beg (gethash :line-beg symbol-meta))
+              (col-beg (gethash :col-beg symbol-meta))
+              (name (gethash :name symbol-meta))
+              (match (gethash :match symbol-meta)))
+          (with-current-buffer
+              (cljr--find-file-noselect file)
+            (goto-char (point-min))
+            (forward-line (1- line-beg))
+            (move-to-column (1- col-beg))
+            (cond
+             ((cljr--ignorable-occurrence-p) :do-nothing)
+             ((cljr--call-site-p name) (cljr--update-call-site signature-changes))
+             ((cljr--partial-call-site-p)
+              (cljr--update-partial-call-site signature-changes))
+             ((cljr--apply-call-site-p)
+              (cljr--update-apply-call-site signature-changes))
+             ((cljr--defnp match)
+              (cljr--update-function-signature signature-changes))
+             (t (cljr--append-to-manual-intervention-buffer)))
+            (save-buffer))))))
   (unless (cljr--empty-buffer-p (get-buffer-create cljr--manual-intervention-buffer))
     (pop-to-buffer cljr--manual-intervention-buffer)
     (goto-char (point-min))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -3,6 +3,7 @@
 (require 'paredit)
 (require 'clj-refactor)
 (require 'buttercup)
+(require 'cl-lib)
 
 ;; NOTE: please remember, without an `it` block, your tests will not be run!
 ;; You can learn about Buttercup's syntax here:
@@ -424,3 +425,43 @@ ex/"))))
         (unless (eq command 'clj-refactor-menu)
           (let ((suffix (ignore-errors (transient-get-suffix 'clj-refactor-menu key))))
             (expect suffix :not :to-be nil)))))))
+
+(describe "cljr--with-opened-buffers"
+  (it "kills buffers it opens but leaves already-visited ones alone"
+    (let* ((already (make-temp-file "cljrtmp" nil ".txt" "already\n"))
+           (fresh (make-temp-file "cljrtmp" nil ".txt" "fresh\n"))
+           (already-buf (find-file-noselect already)))
+      (unwind-protect
+          (progn
+            (cljr--with-opened-buffers
+              (cljr--find-file-noselect already)
+              (cljr--find-file-noselect fresh))
+            (expect (buffer-live-p already-buf) :to-be-truthy)
+            (expect (get-file-buffer fresh) :to-be nil))
+        (when (buffer-live-p already-buf) (kill-buffer already-buf))
+        (when (get-file-buffer fresh) (kill-buffer (get-file-buffer fresh)))
+        (delete-file already)
+        (delete-file fresh)))))
+
+(describe "cljr--cache-fresh-p"
+  (it "honors the TTL and the disable setting"
+    (let ((cljr-artifact-cache-ttl 300))
+      (expect (cljr--cache-fresh-p (cons (float-time) '("x"))) :to-be-truthy)
+      (expect (cljr--cache-fresh-p (cons (- (float-time) 10000) '("x"))) :to-be nil)
+      (expect (cljr--cache-fresh-p nil) :to-be nil))
+    (let ((cljr-artifact-cache-ttl nil))
+      (expect (cljr--cache-fresh-p (cons (float-time) '("x"))) :to-be nil))))
+
+(describe "cljr--get-artifacts-from-middleware"
+  (it "caches within the TTL and refetches when forced"
+    (let ((cljr-artifact-cache-ttl 300)
+          (cljr--artifacts-cache nil)
+          (calls 0))
+      (cl-letf (((symbol-function 'cljr--call-middleware-sync)
+                 (lambda (&rest _) (setq calls (1+ calls)) '("a" "b")))
+                ((symbol-function 'message) #'ignore))
+        (expect (cljr--get-artifacts-from-middleware nil) :to-equal '("a" "b"))
+        (expect (cljr--get-artifacts-from-middleware nil) :to-equal '("a" "b"))
+        (expect calls :to-equal 1)
+        (cljr--get-artifacts-from-middleware t)
+        (expect calls :to-equal 2)))))


### PR DESCRIPTION
First chunk of the responsiveness work - three focused improvements, no behavior change beyond speed/feedback.

**Stop leaking buffers (#3a).** Rename symbol, inline symbol, and change function signature opened every affected file with `find-file-noselect` and never killed the ones they opened - accumulating buffers and slowing Emacs on large refactorings (`cljr--update-file` already avoided this for its own path). They now route through a new `cljr--find-file-noselect` + `cljr--with-opened-buffers` pair that kills buffers it opened while leaving already-visited ones alone.

**Progress during `cljr-project-clean` (#3b).** It looped over every project file with no feedback, appearing to freeze Emacs. Now shows a `progress-reporter`.

**Cache artifact/version lists (#3c).** The dependency commands re-fetched the artifact list (and, uncached, per-artifact versions) on every invocation. Now cached with a configurable TTL (`cljr-artifact-cache-ttl`, default 300s; nil to disable).

Adds unit tests for the buffer-tracking helper and the cache. Compile clean (`--warnings-as-errors`), lint clean, 62 buttercup specs pass.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)