### PR TITLE
Cache cljr-slash libspec suggestions per alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Performance: project-wide refactorings (rename symbol, inline symbol, change function signature) no longer leave behind buffers they had to open, which previously slowed Emacs down on large renames.
 - `cljr-project-clean` now shows a progress reporter instead of freezing Emacs silently.
 - Performance: cache the artifact and version lists fetched by the dependency commands, so they aren't re-requested on every invocation. The TTL is configurable via `cljr-artifact-cache-ttl` (default 300s; set to nil to disable).
+- Performance: `cljr-slash` caches libspec suggestions per alias (also governed by `cljr-artifact-cache-ttl`), so repeatedly typing an unresolved alias like `str/` no longer does a middleware round-trip on every `/`.
 - **(Breaking)** Drop the `multiple-cursors`, `hydra` and `inflections` dependencies.
   - The hydra menus are replaced by the new `clj-refactor-menu` transient (see above).
   - The `multiple-cursors` integration is gone; let/extract/promote refactorings now always prompt for names. The `cljr-use-multiple-cursors` option is removed.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1978,6 +1978,14 @@ following this convention: `https://stuartsierra.com/2015/05/10/clojure-namespac
                 (cljr--call-middleware-sync "namespace-aliases")
                 parseedn-read-str))
 
+(defvar cljr--suggest-libspecs-cache (make-hash-table :test #'equal)
+  "Cache of `cljr-suggest-libspecs' results used by `cljr-slash'.
+Maps a (alias-ref buffer-context point-context) key to a
+\(timestamp . candidates) cons.  `cljr-slash' fires on every `/'
+keystroke, so caching keeps the common case (typing the same alias, e.g.
+`str/', repeatedly) from doing a middleware round-trip each time.  The
+entries expire per `cljr-artifact-cache-ttl'.")
+
 (defun cljr--call-middleware-suggest-libspec (alias-ref language-context)
   "Suggest namespace require libspecs for an alias.
 
@@ -1995,21 +2003,32 @@ buffer if context at current point is nil. See
 
 Passes through the custom `cljr-magic-require-namespaces' so that
 users can specify default recommended alias prefixes that may not
-appear in the project yet."
-  (let ((buffer-context (car language-context))
-        (point-context (cadr language-context)))
-    (thread-first "cljr-suggest-libspecs"
-                  cljr--ensure-op-supported
-                  (cljr--create-msg "lib-prefix" alias-ref
-                                    "language-context" buffer-context
-                                    "buffer-language-context" buffer-context
-                                    "input-language-context" (or point-context buffer-context)
-                                    "preferred-aliases" (let ((print-length nil) ;; prevent large lists from being serialized with `...`, which would cause issues
-                                                              (print-level nil))
-                                                          (prin1-to-string cljr-magic-require-namespaces)))
-                  (cljr--call-middleware-sync "suggestions")
-                  parseedn-read-str
-                  (seq-into 'list))))
+appear in the project yet.
+
+Results are cached per alias and language context (see
+`cljr--suggest-libspecs-cache' and `cljr-artifact-cache-ttl'), since
+`cljr-slash' calls this on every `/' keystroke."
+  (let* ((buffer-context (car language-context))
+         (point-context (cadr language-context))
+         (key (list alias-ref buffer-context point-context))
+         (cached (gethash key cljr--suggest-libspecs-cache)))
+    (if (cljr--cache-fresh-p cached)
+        (cdr cached)
+      (let ((candidates
+             (thread-first "cljr-suggest-libspecs"
+                           cljr--ensure-op-supported
+                           (cljr--create-msg "lib-prefix" alias-ref
+                                             "language-context" buffer-context
+                                             "buffer-language-context" buffer-context
+                                             "input-language-context" (or point-context buffer-context)
+                                             "preferred-aliases" (let ((print-length nil) ;; prevent large lists from being serialized with `...`, which would cause issues
+                                                                       (print-level nil))
+                                                                   (prin1-to-string cljr-magic-require-namespaces)))
+                           (cljr--call-middleware-sync "suggestions")
+                           parseedn-read-str
+                           (seq-into 'list))))
+        (puthash key (cons (float-time) candidates) cljr--suggest-libspecs-cache)
+        candidates))))
 
 (defun cljr--language-context-at-point ()
   "Detects the current language-context at a given point.
@@ -2361,13 +2380,17 @@ If it's present KEY indicates the key to extract from the response."
   (cider-nrepl-send-request request callback))
 
 (defcustom cljr-artifact-cache-ttl 300
-  "Number of seconds to cache artifact and version lists on the Emacs side.
+  "Number of seconds to cache middleware lookups whose results change rarely.
 
-The dependency commands (`cljr-add-project-dependency' and friends) fetch
-the list of available artifacts, and the versions of a given artifact,
-from the middleware.  Those lists change rarely, so they are cached for
-this many seconds to avoid a round-trip on every invocation.  Set to nil
-to disable the cache."
+This governs two Emacs-side caches:
+
+- The dependency commands (`cljr-add-project-dependency' and friends) fetch
+  the list of available artifacts, and the versions of a given artifact.
+- `cljr-slash' fetches libspec suggestions for an unresolved alias on every
+  `/' keystroke.
+
+Caching these for this many seconds avoids a middleware round-trip on every
+invocation.  Set to nil to disable the caches."
   :type '(choice (const :tag "Disable" nil) integer)
   :package-version '(clj-refactor . "4.0.0")
   :safe (lambda (x) (or (null x) (integerp x))))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -465,3 +465,19 @@ ex/"))))
         (expect calls :to-equal 1)
         (cljr--get-artifacts-from-middleware t)
         (expect calls :to-equal 2)))))
+
+(describe "cljr--call-middleware-suggest-libspec"
+  (it "caches suggestions per alias within the TTL"
+    (let ((cljr-artifact-cache-ttl 300)
+          (cljr--suggest-libspecs-cache (make-hash-table :test #'equal))
+          (calls 0))
+      (cl-letf (((symbol-function 'cljr--ensure-op-supported) (lambda (op) op))
+                ((symbol-function 'cljr--call-middleware-sync)
+                 (lambda (&rest _) (setq calls (1+ calls)) "([clojure.set :as set])")))
+        (let ((first (cljr--call-middleware-suggest-libspec "set" '("clj" nil)))
+              (second (cljr--call-middleware-suggest-libspec "set" '("clj" nil))))
+          (expect calls :to-equal 1)
+          (expect second :to-equal first))
+        ;; a different alias is a cache miss
+        (cljr--call-middleware-suggest-libspec "io" '("clj" nil))
+        (expect calls :to-equal 2)))))


### PR DESCRIPTION
`cljr-slash` fires on every `/` keystroke and, for an unresolved alias, did a **synchronous** `suggest-libspecs` middleware round-trip each time - felt directly while typing `str/`, `io/`, etc. This caches the suggestions per `(alias, language-context)` (expiring per `cljr-artifact-cache-ttl`), so repeated use of the same alias is instant.

It's safe because `cljr-slash` only queries for *unresolved* aliases - once a require is added the alias resolves and isn't queried again, so the cache never causes an already-required suggestion.

Full async was avoided deliberately: the flow can prompt for a libspec (multiple candidates), and firing that prompt from an async callback would interrupt the user mid-typing. Per-alias caching is the approach the audit called out as equivalent, without that risk.

Adds a caching test; the existing cljr-slash specs still pass. Compile clean (`--warnings-as-errors`), lint clean, 63 buttercup specs.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)