### PR TITLE
Surface collection-type conversions in the menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.
+- Surface clojure-mode's collection-type conversions (`clojure-convert-collection-to-list`/`-map`/`-vector`/`-set`/`-quoted-list`) in `clj-refactor-menu` under "Convert collection to", so they're discoverable from clj-refactor.
 - Performance: project-wide refactorings (rename symbol, inline symbol, change function signature) no longer leave behind buffers they had to open, which previously slowed Emacs down on large renames.
 - `cljr-project-clean` now shows a progress reporter instead of freezing Emacs silently.
 - Performance: cache the artifact and version lists fetched by the dependency commands, so they aren't re-requested on every invocation. The TTL is configurable via `cljr-artifact-cache-ttl` (default 300s; set to nil to disable).

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -548,6 +548,13 @@ current session."
    ["clj-refactor"
     ("sc" "Show the changelog" cljr-show-changelog)
     ("?" "Describe refactoring" cljr-describe-refactoring)]
+   ["Convert collection to"
+    ;; These commands live in clojure-mode; surfaced here for discoverability.
+    ("xl" "List" clojure-convert-collection-to-list)
+    ("xq" "Quoted list" clojure-convert-collection-to-quoted-list)
+    ("xm" "Map" clojure-convert-collection-to-map)
+    ("xv" "Vector" clojure-convert-collection-to-vector)
+    ("xs" "Set" clojure-convert-collection-to-set)]
    ["Options"
     ("W" cljr--toggle-warn-on-eval)
     ("N" cljr--toggle-auto-clean-ns)


### PR DESCRIPTION
`clojure-mode` already provides `clojure-convert-collection-to-list`/`-map`/`-vector`/`-set`/`-quoted-list` (the old `cljr-cycle-coll` was removed in 2.3.0 precisely because this moved to clojure-mode). So rather than reimplement, this adds a "Convert collection to" group to `clj-refactor-menu` that invokes them - discoverable from clj-refactor without duplicating logic.

This is what #4c ("cycle/toggle collection type") reduces to on inspection. The other #4c idea, "fill missing case/cond branches," isn't well-defined for Clojure without type/analysis info, so it's not included.

Compile clean (`--warnings-as-errors`), lint clean, 62 buttercup specs pass.

- [x] The commits are consistent with our contribution guidelines
- [ ] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)