### PR TITLE
Make cljr-slash work without a running REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `cljr-slash` now works without a running REPL. When refactor-nrepl's `suggest-libspecs` op isn't available, it falls back to the static `cljr-magic-require-namespaces` table (honoring each entry's `:only` language context) instead of erroring, so common aliases like `str`/`io` still get required before you jack in.
 - Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.
 - Surface clojure-mode's collection-type conversions (`clojure-convert-collection-to-list`/`-map`/`-vector`/`-set`/`-quoted-list`) in `clj-refactor-menu` under "Convert collection to", so they're discoverable from clj-refactor.
 - Performance: project-wide refactorings (rename symbol, inline symbol, change function signature) no longer leave behind buffers they had to open, which previously slowed Emacs down on large renames.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2164,6 +2164,40 @@ Filters out existing alias in the namespace, or a global alias
     (cljr--indent-defun)
     (cljr--post-command-message "Required %s" libspec)))
 
+(defun cljr--slash-suggest-op-available-p ()
+  "Non-nil when the `cljr-suggest-libspecs' middleware op can be used.
+When it can't (e.g. no REPL is connected yet), `cljr-slash' falls back to
+the static `cljr-magic-require-namespaces' table."
+  (cljr--op-supported-p "cljr-suggest-libspecs"))
+
+(defun cljr--magic-require-libspec-from-table (alias-ref)
+  "Return a libspec string for ALIAS-REF from `cljr-magic-require-namespaces'.
+Return nil when the alias isn't in the table, or when the table entry is
+restricted (via `:only') to language contexts that exclude the current
+one.  This is the offline fallback used by `cljr-slash' when the
+suggest-libspecs middleware isn't available."
+  (when-let* ((entry (assoc alias-ref cljr-magic-require-namespaces)))
+    (let (ns only)
+      (if (consp (cdr entry))
+          (setq ns (cadr entry)
+                only (plist-get (cddr entry) :only))
+        (setq ns (cdr entry)))
+      (let ((context (car (cljr--language-context-at-point))))
+        (when (or (null only)
+                  (equal context "cljc")
+                  (member context only))
+          (format "[%s :as %s]" ns alias-ref))))))
+
+(defun cljr--slash-suggested-libspec (alias-ref)
+  "Return a libspec string to require for ALIAS-REF, or nil.
+Use the `cljr-suggest-libspecs' middleware op when it is available, and
+otherwise fall back to `cljr-magic-require-namespaces', so that common
+aliases still work without a running REPL."
+  (if (cljr--slash-suggest-op-available-p)
+      (cljr--prompt-or-select-libspec
+       (cljr--call-middleware-suggest-libspec alias-ref (cljr--language-context-at-point)))
+    (cljr--magic-require-libspec-from-table alias-ref)))
+
 ;;;###autoload
 (defun cljr-slash ()
   "Inserts `/' as normal, but also checks for common namespace shorthands to require.
@@ -2184,11 +2218,10 @@ to the ns form."
                               (clojure-find-ns)
                               (cljr--unresolved-alias-ref (cljr--ns-alias-at-point)))))
     (if cljr-slash-uses-suggest-libspec
-        ;; creates suggestions from `suggest-libspec' middleware op
-        (when-let* ((libspec
-                     (thread-first alias-ref
-                                   (cljr--call-middleware-suggest-libspec (cljr--language-context-at-point))
-                                   cljr--prompt-or-select-libspec)))
+        ;; Use the `cljr-suggest-libspecs' middleware op when it's available,
+        ;; otherwise fall back to the static `cljr-magic-require-namespaces'
+        ;; table so common aliases still work without a running REPL.
+        (when-let* ((libspec (cljr--slash-suggested-libspec alias-ref)))
           ;; only insert a require if a candidate exists and was selected
           (cljr--insert-require-libspec libspec))
       ;; Deprecated, creates suggestions from `namespace-aliases' middleware op

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -364,6 +364,7 @@
 
 (describe "cljr-slash"
   (it "inserts single selection from suggest-libspec"
+    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value t)
     (spy-on 'cljr--call-middleware-suggest-libspec
             :and-return-value (parseedn-read-str "[\"[bar.alias :as alias]\"]"))
     (cljr--with-clojure-temp-file "foo.cljc"
@@ -375,6 +376,7 @@
 alias/")))
 
   (it "prompts user for selection from suggest-libspec"
+    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value t)
     (spy-on 'cljr--call-middleware-suggest-libspec
             :and-return-value (parseedn-read-str "[\"[bar.example :as ex]\" \"[baz.example :as ex]\"]"))
     (spy-on 'completing-read
@@ -388,6 +390,7 @@ alias/")))
 ex/")))
 
   (it "inserts modified user input from completing-read"
+    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value t)
     (spy-on 'cljr--call-middleware-suggest-libspec
             :and-return-value (parseedn-read-str "[\"[bar.example :as ex]\" \"[baz.example :as ex]\"]"))
     (spy-on 'completing-read
@@ -399,6 +402,17 @@ ex/")))
       (expect (buffer-string) :to-equal "(ns foo
   (:require [baz.example :as ex :refer [a b c] ]))
 ex/"))))
+
+(describe "cljr-slash offline fallback"
+  (it "inserts a require from the static table when the middleware is unavailable"
+    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value nil)
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(ns foo)\nstr|"
+        (let ((cljr-slash-uses-suggest-libspec t))
+          (cljr-slash)))
+      (expect (buffer-string) :to-equal "(ns foo
+  (:require [clojure.string :as str]))
+str/"))))
 
 (describe "cljr--remove-tramp-prefix-from-msg"
   (it "Removes the tramp prefix from specifc nrepl message attributes"
@@ -481,3 +495,29 @@ ex/"))))
         ;; a different alias is a cache miss
         (cljr--call-middleware-suggest-libspec "io" '("clj" nil))
         (expect calls :to-equal 2)))))
+
+(describe "cljr--magic-require-libspec-from-table"
+  (it "resolves a known alias in a clj file"
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo)")
+      (expect (cljr--magic-require-libspec-from-table "str")
+              :to-equal "[clojure.string :as str]")
+      (expect (cljr--magic-require-libspec-from-table "io")
+              :to-equal "[clojure.java.io :as io]")))
+  (it "honors an entry's :only language context"
+    (cljr--with-clojure-temp-file "foo.cljs"
+      (insert "(ns foo)")
+      ;; io is restricted to clj, so it does not apply in a cljs file
+      (expect (cljr--magic-require-libspec-from-table "io") :to-be nil)
+      ;; but an unrestricted alias still resolves
+      (expect (cljr--magic-require-libspec-from-table "str")
+              :to-equal "[clojure.string :as str]")))
+  (it "is permissive in cljc files"
+    (cljr--with-clojure-temp-file "foo.cljc"
+      (insert "(ns foo)")
+      (expect (cljr--magic-require-libspec-from-table "io")
+              :to-equal "[clojure.java.io :as io]")))
+  (it "returns nil for an unknown alias"
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo)")
+      (expect (cljr--magic-require-libspec-from-table "nope") :to-be nil))))


### PR DESCRIPTION
`cljr-slash` resolves an unresolved alias to a `:require` via the `suggest-libspecs` middleware op. When no REPL is connected, that op-support check (`cljr--ensure-op-supported` → `cljr--assert-middleware`) signals a `user-error` - so typing `/` after an alias did nothing but complain.

This falls back to the static `cljr-magic-require-namespaces` table when the op isn't available: it looks the alias up there (honoring each entry's `:only` language context) and inserts the libspec directly - no network, no error. Common aliases (`str`, `io`, `set`, …) now work before you jack in, and the middleware path is unchanged when a REPL is connected.
Adds buttercup coverage for the table lookup (incl. `:only`/cljc handling) and an end-to-end offline `cljr-slash` test. Compile clean (`--warnings-as-errors`), lint clean, 68 specs pass.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
