### PR TITLE
Let cljr-slash add and hotload a missing library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `cljr-slash` now works without a running REPL. When refactor-nrepl's `suggest-libspecs` op isn't available, it falls back to the static `cljr-magic-require-namespaces` table (honoring each entry's `:only` language context) instead of erroring, so common aliases like `str`/`io` still get required before you jack in.
+- `cljr-slash` can add and hotload a missing library. Entries in `cljr-magic-require-namespaces` may now carry an `:artifact` coordinate (e.g. `("json" "cheshire.core" :artifact "cheshire/cheshire")`); when the namespace isn't on the classpath, `cljr-slash` offers to add that artifact as a project dependency and hotload it. Controlled by the new `cljr-slash-add-missing-libs` (default on).
 - Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.
 - Surface clojure-mode's collection-type conversions (`clojure-convert-collection-to-list`/`-map`/`-vector`/`-set`/`-quoted-list`) in `clj-refactor-menu` under "Convert collection to", so they're discoverable from clj-refactor.
 - Performance: project-wide refactorings (rename symbol, inline symbol, change function signature) no longer leave behind buffers they had to open, which previously slowed Emacs down on large renames.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -98,11 +98,31 @@ paths once this flag is removed."
     ("zip"  . "clojure.zip"))
   "Alist of aliases to namespace libspec recommendations for `\\[cljr-slash]'.
 
-An optional keyword `:only` can limit a recommendation to the set of
-language contexts (clj, cljs) the libspec is available in."
-  :type '(repeat (cons (string :tag "Short alias")
-                       (string :tag "Full namespace")))
+Each entry is either a cons of the alias and the full namespace, e.g.
+\(\"str\" . \"clojure.string\"), or a list of the alias, the namespace and
+optional keywords:
+
+- `:only' limits the recommendation to the given language contexts (clj,
+  cljs), e.g. (\"io\" \"clojure.java.io\" :only (\"clj\")).
+- `:artifact' names the Maven/Clojars coordinate that provides the
+  namespace, e.g. (\"json\" \"cheshire.core\" :artifact \"cheshire/cheshire\").
+  When the namespace isn't on the classpath, `cljr-slash' can offer to add
+  and hotload that artifact (see `cljr-slash-add-missing-libs')."
+  :type '(alist :key-type (string :tag "Short alias")
+                :value-type sexp)
   :safe #'listp)
+
+(defcustom cljr-slash-add-missing-libs t
+  "Whether `cljr-slash' offers to add and hotload a missing library.
+
+When an alias in `cljr-magic-require-namespaces' carries an `:artifact'
+coordinate and the namespace it resolves to isn't on the classpath,
+`cljr-slash' asks whether to add that artifact as a project dependency and
+hotload it (the hotload itself still honors `cljr-hotload-dependencies').
+Set to nil to disable."
+  :type 'boolean
+  :package-version '(clj-refactor . "4.0.0")
+  :safe #'booleanp)
 
 (defcustom cljr-project-clean-prompt t
   "If t, `cljr-project-clean' asks before doing anything.
@@ -2198,6 +2218,44 @@ aliases still work without a running REPL."
        (cljr--call-middleware-suggest-libspec alias-ref (cljr--language-context-at-point)))
     (cljr--magic-require-libspec-from-table alias-ref)))
 
+(defun cljr--magic-require-artifact (alias-ref)
+  "Return the `:artifact' coordinate configured for ALIAS-REF, or nil.
+See `cljr-magic-require-namespaces'."
+  (when-let* ((entry (assoc alias-ref cljr-magic-require-namespaces))
+              ((consp (cdr entry))))
+    (plist-get (cddr entry) :artifact)))
+
+(defun cljr--libspec-ns (libspec)
+  "Return the namespace part of LIBSPEC as a string.
+E.g. \"[foo.bar :as fb]\" -> \"foo.bar\".  Returns nil if LIBSPEC can't be
+parsed."
+  (ignore-errors
+    (symbol-name (aref (car (read-from-string libspec)) 0))))
+
+(defun cljr--ns-on-classpath-p (ns)
+  "Return non-nil when NS resolves to a file on the classpath.
+Requires a connected REPL; returns nil when disconnected."
+  (and (cider-connected-p)
+       (ignore-errors (cider-sync-request:ns-path ns))))
+
+(defun cljr--slash-maybe-add-missing-lib (alias-ref libspec)
+  "Offer to add and hotload the library that provides LIBSPEC's namespace.
+
+Only acts when `cljr-slash-add-missing-libs' is non-nil, ALIAS-REF has an
+`:artifact' configured in `cljr-magic-require-namespaces', a REPL is
+connected, and the namespace isn't already on the classpath.  Adds (with
+confirmation) the artifact at its latest version, hotloading it per
+`cljr-hotload-dependencies'."
+  (when-let* (((and cljr-slash-add-missing-libs (cider-connected-p)))
+              (artifact (cljr--magic-require-artifact alias-ref))
+              (ns (cljr--libspec-ns libspec))
+              ((not (cljr--ns-on-classpath-p ns))))
+    (when (y-or-n-p (format "%s isn't on the classpath.  Add and hotload %s? "
+                            ns artifact))
+      (if-let* ((version (car (cljr--get-versions-from-middleware artifact))))
+          (cljr--add-project-dependency artifact version)
+        (user-error "Couldn't find any versions of %s" artifact)))))
+
 ;;;###autoload
 (defun cljr-slash ()
   "Inserts `/' as normal, but also checks for common namespace shorthands to require.
@@ -2223,6 +2281,7 @@ to the ns form."
         ;; table so common aliases still work without a running REPL.
         (when-let* ((libspec (cljr--slash-suggested-libspec alias-ref)))
           ;; only insert a require if a candidate exists and was selected
+          (cljr--slash-maybe-add-missing-lib alias-ref libspec)
           (cljr--insert-require-libspec libspec))
       ;; Deprecated, creates suggestions from `namespace-aliases' middleware op
       (when-let* ((aliases (cljr--magic-requires-lookup-alias alias-ref)))

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -521,3 +521,52 @@ str/"))))
     (cljr--with-clojure-temp-file "foo.clj"
       (insert "(ns foo)")
       (expect (cljr--magic-require-libspec-from-table "nope") :to-be nil))))
+
+(describe "cljr--magic-require-artifact"
+  (it "reads the :artifact coordinate from a table entry"
+    (let ((cljr-magic-require-namespaces
+           '(("json" "cheshire.core" :artifact "cheshire/cheshire")
+             ("str" . "clojure.string"))))
+      (expect (cljr--magic-require-artifact "json") :to-equal "cheshire/cheshire")
+      (expect (cljr--magic-require-artifact "str") :to-be nil)
+      (expect (cljr--magic-require-artifact "nope") :to-be nil))))
+
+(describe "cljr--libspec-ns"
+  (it "extracts the namespace from a libspec string"
+    (expect (cljr--libspec-ns "[cheshire.core :as json]") :to-equal "cheshire.core")
+    (expect (cljr--libspec-ns "[foo.bar :as fb :refer [a b]]") :to-equal "foo.bar")))
+
+(describe "cljr--slash-maybe-add-missing-lib"
+  (before-each
+    (spy-on 'cljr--add-project-dependency)
+    (spy-on 'cider-connected-p :and-return-value t)
+    (spy-on 'cljr--get-versions-from-middleware :and-return-value '("1.2.3"))
+    (spy-on 'y-or-n-p :and-return-value t))
+  (it "adds the configured artifact when the namespace is missing"
+    (spy-on 'cljr--ns-on-classpath-p :and-return-value nil)
+    (let ((cljr-slash-add-missing-libs t)
+          (cljr-magic-require-namespaces
+           '(("json" "cheshire.core" :artifact "cheshire/cheshire"))))
+      (cljr--slash-maybe-add-missing-lib "json" "[cheshire.core :as json]")
+      (expect 'cljr--add-project-dependency
+              :to-have-been-called-with "cheshire/cheshire" "1.2.3")))
+  (it "does nothing when the namespace is already on the classpath"
+    (spy-on 'cljr--ns-on-classpath-p :and-return-value "/path/cheshire/core.clj")
+    (let ((cljr-slash-add-missing-libs t)
+          (cljr-magic-require-namespaces
+           '(("json" "cheshire.core" :artifact "cheshire/cheshire"))))
+      (cljr--slash-maybe-add-missing-lib "json" "[cheshire.core :as json]")
+      (expect 'cljr--add-project-dependency :not :to-have-been-called)))
+  (it "does nothing when disabled"
+    (spy-on 'cljr--ns-on-classpath-p :and-return-value nil)
+    (let ((cljr-slash-add-missing-libs nil)
+          (cljr-magic-require-namespaces
+           '(("json" "cheshire.core" :artifact "cheshire/cheshire"))))
+      (cljr--slash-maybe-add-missing-lib "json" "[cheshire.core :as json]")
+      (expect 'cljr--add-project-dependency :not :to-have-been-called)))
+  (it "does nothing when no :artifact is configured"
+    (spy-on 'cljr--ns-on-classpath-p :and-return-value nil)
+    (let ((cljr-slash-add-missing-libs t)
+          (cljr-magic-require-namespaces '(("str" . "clojure.string"))))
+      (cljr--slash-maybe-add-missing-lib "str" "[clojure.string :as str]")
+      (expect 'cljr--add-project-dependency :not :to-have-been-called))))


### PR DESCRIPTION
Entries in `cljr-magic-require-namespaces` can now carry an `:artifact` coordinate:

```elisp
("json" "cheshire.core" :artifact "cheshire/cheshire")
```

When `cljr-slash` resolves an alias to such an entry and the namespace isn't on the classpath, it offers (with confirmation) to add that artifact at its latest version as a project dependency - reusing `cljr--add-project-dependency`, which hotloads per `cljr-hotload-dependencies`. Gated by the new `cljr-slash-add-missing-libs` (default on), and it only fires for aliases you've explicitly configured with an `:artifact`, so nothing changes for the default table.

The runtime add/hotload composes existing, already-tested commands rather than new middleware logic. Unit tests cover the config parsing (`cljr--magic-require-artifact`, `cljr--libspec-ns`) and the orchestration with mocks (adds when missing; no-ops when the ns is present, when disabled, or when no `:artifact` is set). The live add+hotload path is REPL-dependent and not exercised by the suite.

Compile clean (`--warnings-as-errors`), lint clean, 74 buttercup specs pass.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
