### PR TITLE
Revert cljr-require-alias-at-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Add `cljr-require-alias-at-point` (mnemonic `ra`): add a require for the unresolved namespace alias of the symbol at point, without retyping `/` - handy after pasting code that uses an alias which isn't required yet. It resolves the alias the same way `cljr-slash` does (works offline, and can add a missing library).
 - `cljr-slash` now works without a running REPL. When refactor-nrepl's `suggest-libspecs` op isn't available, it falls back to the static `cljr-magic-require-namespaces` table (honoring each entry's `:only` language context) instead of erroring, so common aliases like `str`/`io` still get required before you jack in.
 - `cljr-slash` can add and hotload a missing library. Entries in `cljr-magic-require-namespaces` may now carry an `:artifact` coordinate (e.g. `("json" "cheshire.core" :artifact "cheshire/cheshire")`); when the namespace isn't on the classpath, `cljr-slash` offers to add that artifact as a project dependency and hotload it. Controlled by the new `cljr-slash-add-missing-libs` (default on).
 - Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -409,7 +409,6 @@ Buffers that were already being visited before BODY ran are left alone."
     ("am" . (cljr-add-missing-libspec "Add missing libspec" ?m ("ns")))
     ("ap" . (cljr-add-project-dependency "Add project dependency" ?p ("ns" "project")))
     ("ar" . (cljr-add-require-to-ns "Add require to ns" ?r ("ns")))
-    ("ra" . (cljr-require-alias-at-point "Require the alias at point" ?a ("ns")))
     ("as" . (cljr-add-stubs "Add stubs for the interface/protocol at point" ?s ("toplevel-form")))
     ("au" . (cljr-add-use-to-ns "Add use to ns" ?U ("ns")))
     ("ci" . (clojure-cycle-if "Cycle if" ?I ("code")))
@@ -528,7 +527,6 @@ current session."
     ("ai" "Add import to ns" cljr-add-import-to-ns)
     ("am" "Add missing libspec" cljr-add-missing-libspec)
     ("ar" "Add require to ns" cljr-add-require-to-ns)
-    ("ra" "Require alias at point" cljr-require-alias-at-point)
     ("au" "Add use to ns" cljr-add-use-to-ns)
     ("cn" "Clean ns" cljr-clean-ns)
     ("rm" "Require macro" cljr-require-macro)
@@ -2257,32 +2255,6 @@ confirmation) the artifact at its latest version, hotloading it per
       (if-let* ((version (car (cljr--get-versions-from-middleware artifact))))
           (cljr--add-project-dependency artifact version)
         (user-error "Couldn't find any versions of %s" artifact)))))
-
-;;;###autoload
-(defun cljr-require-alias-at-point ()
-  "Add a require for the unresolved namespace alias of the symbol at point.
-
-Like `cljr-slash', but it works when the `/' is already present - for
-example after pasting code that uses an alias which isn't required yet.
-Point may be anywhere in the aliased symbol (e.g. on `str/join').
-
-Resolves the alias the same way `cljr-slash' does, so it works offline via
-`cljr-magic-require-namespaces' and can add a missing library (see
-`cljr-slash-add-missing-libs')."
-  (interactive)
-  (let* ((symbol (cider-symbol-at-point))
-         (alias (when (and symbol (string-search "/" symbol))
-                  (car (split-string symbol "/"))))
-         (alias-ref (and alias
-                         (clojure-find-ns)
-                         (cljr--unresolved-alias-ref alias))))
-    (unless alias-ref
-      (user-error "No unresolved namespace alias at point"))
-    (if-let* ((libspec (cljr--slash-suggested-libspec alias-ref)))
-        (progn
-          (cljr--slash-maybe-add-missing-lib alias-ref libspec)
-          (cljr--insert-require-libspec libspec))
-      (user-error "Couldn't find a namespace for the alias `%s'" alias-ref))))
 
 ;;;###autoload
 (defun cljr-slash ()

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -570,18 +570,3 @@ str/"))))
           (cljr-magic-require-namespaces '(("str" . "clojure.string"))))
       (cljr--slash-maybe-add-missing-lib "str" "[clojure.string :as str]")
       (expect 'cljr--add-project-dependency :not :to-have-been-called))))
-
-(describe "cljr-require-alias-at-point"
-  (it "requires the unresolved alias of the symbol at point (offline)"
-    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value nil)
-    (cljr--with-clojure-temp-file "foo.clj"
-      (with-point-at "(ns foo)\n(str/joi|n [])"
-        (cljr-require-alias-at-point))
-      (expect (buffer-string) :to-equal "(ns foo
-  (:require [clojure.string :as str]))
-(str/join [])")))
-  (it "errors when there is no unresolved alias at point"
-    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value nil)
-    (cljr--with-clojure-temp-file "foo.clj"
-      (with-point-at "(ns foo)\n(printl|n :x)"
-        (expect (cljr-require-alias-at-point) :to-throw 'user-error)))))


### PR DESCRIPTION
Reverts the recently-added `cljr-require-alias-at-point`.

As [rrudakov pointed out](https://github.com/clojure-emacs/clj-refactor.el/pull/583#issuecomment-4934115314), it overlaps with the existing `cljr-add-missing-libspec`, which already requires the aliased symbol at point (`str/join` -> aliases the ns to `str`). The only thing the new command added over it was working without a REPL, which is too niche to justify a second, overlapping command and the extra `ra` binding.

Removes the command, its `ra` keybinding, the `clj-refactor-menu` entry, the tests, and the changelog entry.