### PR TITLE
Give cljr-add-missing-libspec an offline fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `cljr-add-missing-libspec` degrades gracefully without a REPL. For an aliased symbol like `str/join`, when refactor-nrepl's `resolve-missing` op isn't available (or finds nothing) it now falls back to `cljr-magic-require-namespaces` - so common aliases still work offline, and a missing library can be added and hotloaded (see `cljr-slash-add-missing-libs`). Previously it errored without a connected REPL.
 - `cljr-slash` now works without a running REPL. When refactor-nrepl's `suggest-libspecs` op isn't available, it falls back to the static `cljr-magic-require-namespaces` table (honoring each entry's `:only` language context) instead of erroring, so common aliases like `str`/`io` still get required before you jack in.
 - `cljr-slash` can add and hotload a missing library. Entries in `cljr-magic-require-namespaces` may now carry an `:artifact` coordinate (e.g. `("json" "cheshire.core" :artifact "cheshire/cheshire")`); when the namespace isn't on the classpath, `cljr-slash` offers to add that artifact as a project dependency and hotload it. Controlled by the new `cljr-slash-add-missing-libs` (default on).
 - Add `clj-refactor-menu`, a `transient` menu of all commands grouped by category (bound to `hh` under your keybinding prefix, e.g. `C-c C-m hh`). It mirrors the two-letter keybindings, so it doubles as a way to learn them, and its Options section toggles common settings for the session.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -3327,6 +3327,23 @@ itself might be `nil'."
   (when (and cljr-auto-eval-ns-form (cider-connected-p))
     (cider-eval-ns-form)))
 
+(defun cljr--add-missing-libspec-from-alias (symbol)
+  "Add a require for the alias of SYMBOL from `cljr-magic-require-namespaces'.
+
+Handles the `alias/name' case the same way `cljr-slash' does: it works
+without a REPL (via the static table) and, when `cljr-slash-add-missing-libs'
+is set and the alias has an `:artifact', can offer to add and hotload the
+library.  Returns non-nil when it added a require."
+  (when-let* ((alias (and symbol
+                          (string-search "/" symbol)
+                          (car (split-string symbol "/"))))
+              (alias-ref (and (clojure-find-ns)
+                              (cljr--unresolved-alias-ref alias)))
+              (libspec (cljr--slash-suggested-libspec alias-ref)))
+    (cljr--slash-maybe-add-missing-lib alias-ref libspec)
+    (cljr--insert-require-libspec libspec)
+    t))
+
 ;;;###autoload
 (defun cljr-add-missing-libspec ()
   "Requires or imports the symbol at point.
@@ -3334,17 +3351,29 @@ itself might be `nil'."
 If the symbol at point is of the form str/join then the ns
 containing join will be aliased to str.
 
+Uses refactor-nrepl's `resolve-missing' op when it is available.  When it
+isn't (e.g. no REPL is connected) or it finds nothing, falls back to
+resolving an `alias/name' symbol via `cljr-magic-require-namespaces', so
+common aliases still work offline and a missing library can be added (see
+`cljr-slash-add-missing-libs').
+
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-missing-libspec"
   (interactive)
-  (cljr--ensure-op-supported "resolve-missing")
-  (let* ((symbol (cider-symbol-at-point))
-         (candidates (cljr--call-middleware-to-resolve-missing symbol (cider-current-ns))))
-    (if (and candidates (< 0 (length candidates)))
-        (progn
-          (cljr--add-missing-libspec symbol candidates)
-          (cljr--maybe-clean-ns)
-          (cljr--maybe-eval-ns-form))
-      (cljr--post-command-message "Can't find `%s' on classpath" (cljr--symbol-suffix symbol)))))
+  (let ((symbol (cider-symbol-at-point)))
+    (if (cljr--op-supported-p "resolve-missing")
+        (let ((candidates (cljr--call-middleware-to-resolve-missing symbol (cider-current-ns))))
+          (cond
+           ((and candidates (< 0 (length candidates)))
+            (cljr--add-missing-libspec symbol candidates)
+            (cljr--maybe-clean-ns)
+            (cljr--maybe-eval-ns-form))
+           ((cljr--add-missing-libspec-from-alias symbol))
+           (t (cljr--post-command-message "Can't find `%s' on classpath"
+                                          (cljr--symbol-suffix symbol)))))
+      (or (cljr--add-missing-libspec-from-alias symbol)
+          (user-error "Can't resolve `%s': the refactor-nrepl `resolve-missing' \
+op isn't available and the alias isn't in `cljr-magic-require-namespaces'"
+                      symbol)))))
 
 (defun cljr--dependency-at-point ()
   "Returns project dependency at point.

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -570,3 +570,20 @@ str/"))))
           (cljr-magic-require-namespaces '(("str" . "clojure.string"))))
       (cljr--slash-maybe-add-missing-lib "str" "[clojure.string :as str]")
       (expect 'cljr--add-project-dependency :not :to-have-been-called))))
+
+(describe "cljr-add-missing-libspec (offline fallback)"
+  (it "requires an aliased symbol via the table when resolve-missing is unavailable"
+    (spy-on 'cljr--op-supported-p :and-return-value nil)
+    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value nil)
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(ns foo)\n(str/joi|n [])"
+        (cljr-add-missing-libspec))
+      (expect (buffer-string) :to-equal "(ns foo
+  (:require [clojure.string :as str]))
+(str/join [])")))
+  (it "errors on a non-alias symbol when resolve-missing is unavailable"
+    (spy-on 'cljr--op-supported-p :and-return-value nil)
+    (spy-on 'cljr--slash-suggest-op-available-p :and-return-value nil)
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(ns foo)\n(printl|n :x)"
+        (expect (cljr-add-missing-libspec) :to-throw 'user-error)))))


### PR DESCRIPTION
`cljr-add-missing-libspec` hard-required the `resolve-missing` middleware op, so it errored without a REPL, and dead-ended with "Can't find on classpath" when a referenced library wasn't a dependency.

This keeps the `resolve-missing` path (its main, symbol-based resolution), but when the op is unavailable or finds nothing, falls back to resolving an `alias/name` symbol via `cljr-magic-require-namespaces` - the same logic `cljr-slash` uses. So `cljr-add-missing-libspec` now:

- works offline for known aliases (`str/join` -> requires `clojure.string`) instead of erroring, and
- can offer to add and hotload a missing library when the alias has an `:artifact` configured (`cljr-slash-add-missing-libs`).

This folds the two genuinely-useful bits of the reverted `cljr-require-alias-at-point` into the existing command, rather than adding a separate, overlapping one - which is what the reverted command's review feedback pointed toward.

Full suite green: 76 buttercup specs + 146 ecukes scenarios, 0 failed (the ecukes add-missing tests exercise the insertion helper directly, so they're unaffected). Compile clean (`--warnings-as-errors`), lint clean.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)