### PR TITLE
Fix correctness issues in several commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix `cljr-add-declaration` treating a name as "already declared" when it merely contains, or is contained by, another symbol - names with regexp specials like `*db*` or `valid?` were matched incorrectly.
+- `cljr-describe-refactoring` now opens the refactoring's wiki page in your browser. The previous in-Emacs rendering scraped the wiki's HTML, which broke when GitHub changed its markup and 404'd for the clojure-mode commands in the menu; the candidate list is now limited to the `cljr-*` commands that actually have wiki pages. This also drops the `sgml-mode` dependency.
+- `cljr-add-project-dependency`/`cljr-update-project-dependency`: give a clear error instead of a raw "search failed" when the project file has no `:deps`/`:dependencies`, and drop a stray, no-op middleware check after hotloading.
+
 - `cljr-add-missing-libspec` degrades gracefully without a REPL. For an aliased symbol like `str/join`, when refactor-nrepl's `resolve-missing` op isn't available (or finds nothing) it now falls back to `cljr-magic-require-namespaces` - so common aliases still work offline, and a missing library can be added and hotloaded (see `cljr-slash-add-missing-libs`). Previously it errored without a connected REPL.
 - `cljr-slash` now works without a running REPL. When refactor-nrepl's `suggest-libspecs` op isn't available, it falls back to the static `cljr-magic-require-namespaces` table (honoring each entry's `:only` language context) instead of erroring, so common aliases like `str`/`io` still get required before you jack in.
 - `cljr-slash` can add and hotload a missing library. Entries in `cljr-magic-require-namespaces` may now carry an `:artifact` coordinate (e.g. `("json" "cheshire.core" :artifact "cheshire/cheshire")`); when the namespace isn't on the classpath, `cljr-slash` offers to add that artifact as a project dependency and hotload it. Controlled by the new `cljr-slash-add-missing-libs` (default on).

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -38,7 +38,6 @@
 (require 'clojure-mode)
 (require 'cider)
 (require 'parseedn)
-(require 'sgml-mode)
 (require 'transient)
 (require 'subword)
 
@@ -1638,7 +1637,11 @@ optionally including those that are declared private."
 (defun cljr--already-declared-p (def)
   (save-excursion
     (cljr--goto-declare)
-    (re-search-backward def (cljr--point-after 'paredit-backward) :no-error)))
+    ;; `def' is a symbol name; quote it and match on symbol boundaries so
+    ;; names containing regexp specials (*foo*, valid?, +, ...) work and we
+    ;; don't match a longer symbol that merely contains it.
+    (re-search-backward (concat "\\_<" (regexp-quote def) "\\_>")
+                        (cljr--point-after 'paredit-backward) :no-error)))
 
 (defun cljr--add-declaration (def)
   (when (cljr--already-declared-p def)
@@ -2605,14 +2608,16 @@ possible choices. If the choice is trivial, return it."
     (read-from-minibuffer prompt)))
 
 (defun cljr--insert-into-leiningen-dependencies (artifact version)
-  (re-search-forward ":dependencies")
+  (unless (re-search-forward ":dependencies" nil :no-error)
+    (user-error "Couldn't find a `:dependencies' vector in the project file"))
   (paredit-forward)
   (paredit-backward-down)
   (newline-and-indent)
   (insert "[" artifact " \"" version "\"]"))
 
 (defun cljr--insert-into-clj-dependencies (artifact version)
-  (re-search-forward ":deps")
+  (unless (re-search-forward ":deps" nil :no-error)
+    (user-error "Couldn't find a `:deps' map in the project file"))
   (forward-sexp)
   (backward-char)
   (newline-and-indent)
@@ -2639,7 +2644,9 @@ possible choices. If the choice is trivial, return it."
 
 ;;;###autoload
 (defun cljr-add-project-dependency (force)
-  "Add a dependency to the project.clj file.
+  "Add a dependency to the project's `deps.edn' or `project.clj'.
+
+With a prefix arg FORCE, refresh the cached artifact list first.
 
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-project-dependency"
   (interactive "P")
@@ -2673,8 +2680,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-add-project-depe
             (insert "\"" artifact-version "\"")
           (insert "\{:mvn/version \"" artifact-version "\"\}")))))
   (when cljr-hotload-dependencies
-    (cljr-hotload-dependency)
-    (cljr--ensure-op-supported "artifact-list")))
+    (cljr-hotload-dependency)))
 
 ;;;###autoload
 (defun cljr-update-project-dependencies ()
@@ -4135,32 +4141,20 @@ at PATH."
     (cljr--make-room-for-toplevel-form)
     (yas-expand-snippet stub)))
 
-(defun cljr--extract-wiki-description (description-buffer)
-  (with-current-buffer description-buffer
-    (goto-char (point-min))
-    (while (not (looking-at-p "<div id=\"wiki-body\""))
-      (delete-char 1))
-    (sgml-skip-tag-forward 1)
-    (buffer-substring (point-min) (point))))
-
 ;;;###autoload
 (defun cljr-describe-refactoring (cljr-fn)
-  "Show the wiki page, in emacs, for one of the available refactorings.
+  "Open the wiki page for one of the available refactorings in a browser.
 
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-describe-refactoring"
-  (interactive (list (cljr--prompt-user-for "Refactoring to describe: "
-                                            (mapcar (lambda (entry) (cadr entry))
-                                                    cljr--all-helpers))))
-  (let* ((wiki-base-url "https://github.com/clojure-emacs/clj-refactor.el/wiki/")
-         (description-buffer "*cljr-describe-refactoring*")
-         (description (cljr--extract-wiki-description
-                       (url-retrieve-synchronously
-                        (concat wiki-base-url cljr-fn)))))
-    (pop-to-buffer description-buffer)
-    (delete-region (point-min) (point-max))
-    (insert description)
-    (shr-render-region (point-min) (point-max))
-    (view-mode 1)))
+  (interactive
+   (list (cljr--prompt-user-for
+          "Refactoring to describe: "
+          ;; Only the cljr-* commands have their own wiki pages; the
+          ;; clojure-mode commands surfaced in the menu don't.
+          (thread-last cljr--all-helpers
+                       (mapcar (lambda (entry) (symbol-name (cadr entry))))
+                       (seq-filter (lambda (name) (string-prefix-p "cljr-" name)))))))
+  (browse-url (concat "https://github.com/clojure-emacs/clj-refactor.el/wiki/" cljr-fn)))
 
 (defun cljr--get-function-params (fn)
   "Retrieve the parameters for FN."

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -587,3 +587,13 @@ str/"))))
     (cljr--with-clojure-temp-file "foo.clj"
       (with-point-at "(ns foo)\n(printl|n :x)"
         (expect (cljr-add-missing-libspec) :to-throw 'user-error)))))
+
+(describe "cljr--already-declared-p"
+  (it "matches declared names with regexp specials, not substrings of a symbol"
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo)\n(declare *db* valid?)")
+      (expect (cljr--already-declared-p "*db*") :to-be-truthy)
+      (expect (cljr--already-declared-p "valid?") :to-be-truthy)
+      ;; these are substrings of the declared symbols, not declared themselves
+      (expect (cljr--already-declared-p "db") :to-be nil)
+      (expect (cljr--already-declared-p "valid") :to-be nil))))


### PR DESCRIPTION
A batch of correctness fixes surfaced by an audit of the public command surface.

- **`cljr-add-declaration`**: `cljr--already-declared-p` passed the def name to `re-search-backward` as a regexp with no `regexp-quote` or symbol boundaries. Names with regexp specials (`*db*`, `valid?`, `+`, …) matched incorrectly, and a substring of a declared symbol counted as already-declared. Now quoted and anchored on symbol boundaries (with a test).
- **`cljr-describe-refactoring`**: the old path scraped the GitHub wiki's live HTML - a `delete-char` loop that would eat the whole buffer if the markup changed, no nil/timeout handling on `url-retrieve-synchronously`, and it offered the `clojure-*` menu commands as candidates (which 404). Replaced with `browse-url`, candidates limited to the `cljr-*` commands that have wiki pages. Drops the now-unused `sgml-mode` dependency.
- **`cljr-add-project-dependency` / `cljr-update-project-dependency`**: bound the `:deps`/`:dependencies` searches and give a clear error when the project file has neither (was a raw "search failed"); remove a stray no-op `cljr--ensure-op-supported` after hotloading; mention deps.edn in the docstring.

Compile clean (`--warnings-as-errors`), lint clean, full suite green: 77 buttercup + 146 ecukes, 0 failed.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)