### PR TITLE
Promote #() literals without a REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `cljr-promote-function`: promoting a `#(...)` literal to `(fn ...)` now works without a REPL - it delegates to clojure-mode's `clojure-promote-fn-literal` instead of a home-grown, less robust converter. Only the `fn` -> `defn` promotion (which needs captured-locals analysis) still requires the middleware, and it no longer shows the "the project will be evaluated" warning for the pure literal case.
+
 - Fix `cljr-add-declaration` treating a name as "already declared" when it merely contains, or is contained by, another symbol - names with regexp specials like `*db*` or `valid?` were matched incorrectly.
 - `cljr-describe-refactoring` now opens the refactoring's wiki page in your browser. The previous in-Emacs rendering scraped the wiki's HTML, which broke when GitHub changed its markup and 404'd for the clojure-mode commands in the menu; the candidate list is now limited to the `cljr-*` commands that actually have wiki pages. This also drops the `sgml-mode` dependency.
 - `cljr-add-project-dependency`/`cljr-update-project-dependency`: give a clear error instead of a raw "search failed" when the project file has no `:deps`/`:dependencies`, and drop a stray, no-op middleware check after hotloading.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2763,35 +2763,13 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-update-project-d
         (backward-char (length (concat " " locals ")"))))
       (insert name))))
 
-(defun cljr--append-fn-parameter (param)
-  (cljr--goto-fn-definition)
-  (paredit-forward-down)
-  (paredit-forward 2)
-  (paredit-backward-down)
-  (if (looking-back "\\[" 1)
-      (insert param)
-    (insert " " param)))
-
-(defun cljr--promote-function-literal ()
-  (delete-char 1)
-  (let ((body (clojure-delete-and-extract-sexp)))
-    (insert "(fn [] " body ")"))
-  (backward-char)
-  (cljr--goto-fn-definition)
-  (let ((fn-start (point))
-        var replacement)
-    (while (re-search-forward "%[1-9&]?" (cljr--point-after 'paredit-forward) t)
-      (setq var (buffer-substring (point) (cljr--point-after 'paredit-backward)))
-      (setq replacement (read-string (format "%s => " var)))
-      (cljr--append-fn-parameter (if (string= "%&" var)
-                                     (format "& %s" replacement)
-                                   replacement))
-      (goto-char (1+ fn-start))
-      (let ((end (cljr--point-after '(paredit-forward-up 2))))
-        (while (re-search-forward (format "\\s-%s\\(\\s-\\|\\|\n)\\)" var)
-                                  end :no-error)
-          (replace-match (format " %s\\1" replacement))))
-      (goto-char fn-start))))
+(defun cljr--promote-to-defn ()
+  "Promote the `fn' at point to a top-level `defn'.
+Uses the `find-used-locals' middleware op to build the argument list, so
+it requires a connected REPL."
+  (cljr--ensure-op-supported "find-used-locals")
+  (when (cljr--asts-y-or-n-p)
+    (cljr--promote-fn)))
 
 ;;;###autoload
 (defun cljr-promote-function (promote-to-defn)
@@ -2799,27 +2777,30 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-update-project-d
 With prefix PROMOTE-TO-DEFN, promote to a defn even if it is a
 function literal.
 
+Promoting a `#(...)' literal to `(fn ...)' is a local edit (it delegates
+to `clojure-promote-fn-literal') and needs no REPL.  Promoting an `fn' to
+a top-level `defn' uses the `find-used-locals' middleware op to build the
+argument list, so it requires a connected REPL.
+
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-promote-function"
   (interactive "P")
-  (cljr--ensure-op-supported "find-used-locals")
-  (when (cljr--asts-y-or-n-p)
-    (save-excursion
-      (cond
-       ;; Already in the right place.
-       ((or (looking-at-p "#(")
-            (looking-at-p "(fn")))
-       ;; Right after the #.
-       ((and (eq (char-after) ?\()
-             (eq (char-before) ?#))
-        (forward-char -1))
-       ;; Possibly inside a function.
-       (t (cljr--goto-fn-definition)))
-      ;; Now promote it.
-      (if (looking-at "#(")
-          (cljr--promote-function-literal)
-        (cljr--promote-fn)))
-    (when promote-to-defn
-      (cljr--promote-fn))))
+  (save-excursion
+    (cond
+     ;; Already in the right place.
+     ((or (looking-at-p "#(")
+          (looking-at-p "(fn")))
+     ;; Right after the #.
+     ((and (eq (char-after) ?\()
+           (eq (char-before) ?#))
+      (forward-char -1))
+     ;; Possibly inside a function.
+     (t (cljr--goto-fn-definition)))
+    ;; Now promote it.
+    (if (looking-at "#(")
+        (clojure-promote-fn-literal)
+      (cljr--promote-to-defn)))
+  (when promote-to-defn
+    (cljr--promote-to-defn)))
 
 (defun cljr--insert-in-find-symbol-buffer (occurrence)
   (save-excursion

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -607,3 +607,13 @@ str/"))))
     (cljr--with-clojure-temp-file "foo.clj"
       (with-point-at "(println| :x)"
         (expect (cljr-cycle-thread) :to-throw 'user-error)))))
+
+(describe "cljr-promote-function"
+  (it "promotes a #() literal to (fn ...) without touching the middleware"
+    ;; the literal->fn path is a local edit and must not require a REPL
+    (spy-on 'cljr--ensure-op-supported
+            :and-call-fake (lambda (&rest _) (error "should not need the middleware")))
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(map |#(foo) xs)"
+        (cljr-promote-function nil))
+      (expect (buffer-string) :to-equal "(map (fn [] (foo)) xs)"))))


### PR DESCRIPTION
`cljr-promote-function` required the `find-used-locals` middleware op - and showed the "the project will be evaluated" warning - even to turn a `#(...)` literal into an `(fn ...)`, which is a purely local edit. Its literal converter also duplicated, less robustly, clojure-mode's `clojure-promote-fn-literal`.

This delegates the `#()` -> `fn` case to `clojure-promote-fn-literal` (pure Emacs, no REPL, no warning), and gates the middleware + warning only on the `fn` -> `defn` promotion, which genuinely needs captured-locals analysis. Removes the now-dead `cljr--promote-function-literal` / `cljr--append-fn-parameter`.

`clojure-promote-fn-literal` has been in clojure-mode since 5.14.0, below our 5.18.0 minimum.

Compile clean (`--warnings-as-errors`), lint clean, full suite green: 80 buttercup + 146 ecukes (incl. the existing `promote-function.feature`), 0 failed. Added a test asserting the literal path doesn't touch the middleware.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)