### PR TITLE
Make cljr-remove-let work without a REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `cljr-promote-function`: promoting a `#(...)` literal to `(fn ...)` now works without a REPL - it delegates to clojure-mode's `clojure-promote-fn-literal` instead of a home-grown, less robust converter. Only the `fn` -> `defn` promotion (which needs captured-locals analysis) still requires the middleware, and it no longer shows the "the project will be evaluated" warning for the pure literal case.
+- `cljr-remove-let` now works without a REPL. It inlines the let's bindings locally - in reverse order, so a binding that refers to an earlier one still resolves - and removes the let, instead of driving `cljr-inline-symbol` (which required the middleware and showed the "the project will be evaluated" warning once per binding).
 
 - Fix `cljr-add-declaration` treating a name as "already declared" when it merely contains, or is contained by, another symbol - names with regexp specials like `*db*` or `valid?` were matched incorrectly.
 - `cljr-describe-refactoring` now opens the refactoring's wiki page in your browser. The previous in-Emacs rendering scraped the wiki's HTML, which broke when GitHub changed its markup and 404'd for the clojure-mode commands in the menu; the candidate list is now limited to the `cljr-*` commands that actually have wiki pages. This also drops the `sgml-mode` dependency.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1828,18 +1828,46 @@ This function only does the actual removal."
   (paredit-forward 2)
   (paredit-splice-sexp-killing-backward))
 
+(defun cljr--let-body-start ()
+  "Return the position of the start of the nearest let form's body."
+  (save-excursion
+    (clojure--goto-let)
+    (down-list)
+    (forward-sexp 2) ; past the `let' symbol and the bindings vector
+    (point)))
+
+(defun cljr--inline-let-binding (bind-var init-expr limit)
+  "Replace occurrences of BIND-VAR with INIT-EXPR up to LIMIT.
+BIND-VAR and INIT-EXPR are strings; LIMIT is a marker.  Only whole-symbol
+occurrences are replaced (see `clojure--sexp-regexp'); INIT-EXPR is
+inserted literally."
+  (let ((case-fold-search nil))
+    (while (re-search-forward (clojure--sexp-regexp bind-var) limit t)
+      ;; the symbol sits between the two boundary chars (groups 1 and 2)
+      (let ((beg (match-end 1))
+            (end (match-beginning 2)))
+        (delete-region beg end)
+        (goto-char beg)
+        (insert init-expr)))))
+
 (defun cljr-remove-let ()
-  "Inlines all variables in the let form and removes it.
+  "Inline all bindings of the nearest let form and remove it.
+
+This is a local edit and does not require a running REPL.  Bindings are
+inlined in reverse order, so a binding that refers to an earlier one is
+resolved correctly.
 
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-remove-let"
   (interactive)
   (save-excursion
-    (let ((*cljr--noninteractive* t)) ; make `cljr-inline-symbol' be quiet
-      (clojure--goto-let)
-      (paredit-forward-down 2)
-      (dotimes (_ (length (save-excursion (cljr--get-let-bindings))))
-        (cljr-inline-symbol)
-        (cljr--skip-past-whitespace-and-comments)))))
+    (clojure--goto-let)
+    (let ((bindings (cljr--get-let-bindings))
+          (body-end (save-excursion (clojure--goto-let) (forward-sexp) (point-marker))))
+      (dolist (binding (reverse bindings))
+        (save-excursion
+          (goto-char (cljr--let-body-start))
+          (cljr--inline-let-binding (car binding) (car (last binding)) body-end)))
+      (cljr--eliminate-let))))
 
 ;; ------ Destructuring ----
 

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -617,3 +617,23 @@ str/"))))
       (with-point-at "(map |#(foo) xs)"
         (cljr-promote-function nil))
       (expect (buffer-string) :to-equal "(map (fn [] (foo)) xs)"))))
+(describe "cljr-remove-let"
+  (before-each
+    ;; the command is a local edit and must not reach for the middleware
+    (spy-on 'cljr--ensure-op-supported
+            :and-call-fake (lambda (&rest _) (error "should not need the middleware"))))
+  (it "inlines a single binding"
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(let [x 1] (+ x| x))"
+        (cljr-remove-let))
+      (expect (string-trim (buffer-string)) :to-equal "(+ 1 1)")))
+  (it "inlines multiple independent bindings"
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(let [x 1 y 2] (+ x| y))"
+        (cljr-remove-let))
+      (expect (string-trim (buffer-string)) :to-equal "(+ 1 2)")))
+  (it "resolves bindings that depend on earlier ones"
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(let [x 1 y (+ x 1)] (* y| y))"
+        (cljr-remove-let))
+      (expect (string-trim (buffer-string)) :to-equal "(* (+ 1 1) (+ 1 1))"))))


### PR DESCRIPTION
Removing a let and inlining its bindings is a purely local structural edit, but `cljr-remove-let` drove `cljr-inline-symbol` once per binding - which required the `extract-definition` middleware op and showed the "the project will be evaluated" warning each time.

Reimplemented locally: inline each binding's value into the let body in **reverse order** (so a binding that refers to an earlier one resolves - e.g. `(let [x 1 y (+ x 1)] (* y y))` -> `(* (+ 1 1) (+ 1 1))`), then splice the let with the existing `cljr--eliminate-let`. It reuses clojure-mode's `clojure--sexp-regexp` for whole-symbol matching, so it's no less accurate than the `move-to-let` direction it mirrors.

Compile clean (`--warnings-as-errors`), lint clean, full suite green: 82 buttercup + 146 ecukes (incl. the existing `let-binding.feature` remove-let scenarios), 0 failed. Added tests for single, multiple, and dependent bindings, each asserting the middleware isn't touched.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)