### PR TITLE
Populate the Emacs-side artifact cache from the async warmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Performance: the background artifact-list warming (on REPL connect, per `cljr-populate-artifact-cache-on-startup`) now populates the Emacs-side cache, not just refactor-nrepl's server-side one. Previously the first `cljr-add-project-dependency`/`cljr-update-project-dependency` still blocked on the full artifact-list transfer even though a warmer had already run; now that common case is served from cache without a middleware round-trip.
 - **(Breaking)** Remove the deprecated `namespace-aliases` code path from `cljr-slash`, along with the `cljr-slash-uses-suggest-libspec`, `cljr-suggest-namespace-aliases` and `cljr-assume-language-context` defcustoms. `cljr-slash` has used the language-context-aware `suggest-libspecs` op (with an offline fallback) by default for a while now; the old path and its options are gone.
 - `cljr-promote-function`: promoting a `#(...)` literal to `(fn ...)` now works without a REPL - it delegates to clojure-mode's `clojure-promote-fn-literal` instead of a home-grown, less robust converter. Only the `fn` -> `defn` promotion (which needs captured-locals analysis) still requires the middleware, and it no longer shows the "the project will be evaluated" warning for the pure literal case.
 - `cljr-remove-let` now works without a REPL. It inlines the let's bindings locally - in reverse order, so a binding that refers to an earlier one still resolves - and removes the let, instead of driving `cljr-inline-symbol` (which required the middleware and showed the "the project will be evaluated" warning once per binding).

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -2426,19 +2426,25 @@ invocation.  Set to nil to disable the caches."
             artifacts)
         (user-error "Empty artifact list received from middleware")))))
 
+(defun cljr--cache-artifacts-from-response (response)
+  "Populate `cljr--artifacts-cache' from an async artifact-list RESPONSE.
+Does nothing for responses without an \"artifacts\" entry (e.g. the
+trailing status message), so the Emacs-side cache is only replaced once
+the list actually arrives."
+  (when-let* ((artifacts (nrepl-dict-get response "artifacts")))
+    (setq cljr--artifacts-cache (cons (float-time) artifacts))
+    (when cljr--debug-mode
+      (message "Artifact cache updated"))))
+
 (defun cljr--update-artifact-cache ()
   (cljr--call-middleware-async (cljr--create-msg "artifact-list"
                                                  "force" "true")
-                               (lambda (_)
-                                 (when cljr--debug-mode
-                                   (message "Artifact cache updated")))))
+                               #'cljr--cache-artifacts-from-response))
 
 (defun cljr--init-artifact-cache ()
   (cljr--call-middleware-async (cljr--create-msg "artifact-list"
                                                  "force" "false")
-                               (lambda (_)
-                                 (when cljr--debug-mode
-                                   (message "Artifact cache updated")))))
+                               #'cljr--cache-artifacts-from-response))
 
 (defun cljr--dictionary-lessp (str1 str2)
   "Return t if STR1 is < STR2 when doing a dictionary compare,

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -476,6 +476,25 @@ str/"))))
         (cljr--get-artifacts-from-middleware t)
         (expect calls :to-equal 2)))))
 
+(describe "cljr--cache-artifacts-from-response"
+  (it "populates the Emacs-side artifact cache from an async response"
+    (let ((cljr--artifacts-cache nil))
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (cljr--cache-artifacts-from-response (nrepl-dict "artifacts" '("a/a" "b/b"))))
+      (expect (cdr cljr--artifacts-cache) :to-equal '("a/a" "b/b"))))
+  (it "ignores responses without an artifacts entry"
+    (let ((cljr--artifacts-cache nil))
+      (cljr--cache-artifacts-from-response (nrepl-dict "status" '("done")))
+      (expect cljr--artifacts-cache :to-be nil)))
+  (it "lets a warmed cache serve without a middleware round-trip"
+    (let ((cljr-artifact-cache-ttl 300)
+          (cljr--artifacts-cache nil))
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (cljr--cache-artifacts-from-response (nrepl-dict "artifacts" '("warmed"))))
+      (spy-on 'cljr--call-middleware-sync)
+      (expect (cljr--get-artifacts-from-middleware nil) :to-equal '("warmed"))
+      (expect 'cljr--call-middleware-sync :not :to-have-been-called))))
+
 (describe "cljr--call-middleware-suggest-libspec"
   (it "caches suggestions per alias within the TTL"
     (let ((cljr-artifact-cache-ttl 300)


### PR DESCRIPTION
The background artifact-list warming that runs on REPL connect (`cljr-populate-artifact-cache-on-startup`, on by default) only warmed refactor-nrepl's server-side cache; its callback logged and discarded the response. So the Emacs-side `cljr--artifacts-cache` stayed empty and the first `cljr-add-project-dependency` still froze on the full artifact-list transfer.

Now both warmers populate `cljr--artifacts-cache` from the response, so that common case is served from cache with no middleware round-trip. Groundwork toward cutting down the synchronous middleware calls that block Emacs.