### PR TITLE
Offline cljr-clean-ns + fix offline op-support check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `cljr-slash` and `cljr-add-missing-libspec` erroring with "No linked CIDER sessions" when used without a connected REPL, instead of falling back to their offline behavior. `cljr--op-supported-p` now returns nil when disconnected rather than signaling.
 - Performance: the background artifact-list warming (on REPL connect, per `cljr-populate-artifact-cache-on-startup`) now populates the Emacs-side cache, not just refactor-nrepl's server-side one. Previously the first `cljr-add-project-dependency`/`cljr-update-project-dependency` still blocked on the full artifact-list transfer even though a warmer had already run; now that common case is served from cache without a middleware round-trip.
 - **(Breaking)** Remove the deprecated `namespace-aliases` code path from `cljr-slash`, along with the `cljr-slash-uses-suggest-libspec`, `cljr-suggest-namespace-aliases` and `cljr-assume-language-context` defcustoms. `cljr-slash` has used the language-context-aware `suggest-libspecs` op (with an offline fallback) by default for a while now; the old path and its options are gone.
 - `cljr-promote-function`: promoting a `#(...)` literal to `(fn ...)` now works without a REPL - it delegates to clojure-mode's `clojure-promote-fn-literal` instead of a home-grown, less robust converter. Only the `fn` -> `defn` promotion (which needs captured-locals analysis) still requires the middleware, and it no longer shows the "the project will be evaluated" warning for the pure literal case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `cljr-clean-ns` degrades gracefully without a REPL. When the `clean-ns` middleware op isn't available it falls back to sorting the ns form with clojure-mode's `clojure-sort-ns` instead of erroring - pruning unused libspecs still needs the middleware and is skipped. Auto-sort after ns changes (`cljr-auto-sort-ns`) now works offline too.
 - Fix `cljr-slash` and `cljr-add-missing-libspec` erroring with "No linked CIDER sessions" when used without a connected REPL, instead of falling back to their offline behavior. `cljr--op-supported-p` now returns nil when disconnected rather than signaling.
 - Performance: the background artifact-list warming (on REPL connect, per `cljr-populate-artifact-cache-on-startup`) now populates the Emacs-side cache, not just refactor-nrepl's server-side one. Previously the first `cljr-add-project-dependency`/`cljr-update-project-dependency` still blocked on the full artifact-list transfer even though a warmer had already run; now that common case is served from cache without a middleware round-trip.
 - **(Breaking)** Remove the deprecated `namespace-aliases` code path from `cljr-slash`, along with the `cljr-slash-uses-suggest-libspec`, `cljr-suggest-namespace-aliases` and `cljr-assume-language-context` defcustoms. `cljr-slash` has used the language-context-aware `suggest-libspecs` op (with an offline fallback) by default for a while now; the old path and its options are gone.

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1011,7 +1011,12 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-rename-file-or-d
 
 (defun cljr--op-supported-p (op)
   "Is the OP we require provided by the current middleware stack?"
-  (cider-nrepl-op-supported-p op))
+  ;; Guard on the connection first: `cider-nrepl-op-supported-p' resolves the
+  ;; REPL with the `ensure' flag and signals `No linked CIDER sessions' when
+  ;; nothing is connected.  We want a plain nil there, so the offline fallbacks
+  ;; that gate on this predicate (`cljr-slash', `cljr-clean-ns', ...) can kick in.
+  (and (cider-connected-p)
+       (cider-nrepl-op-supported-p op)))
 
 (defun cljr--assert-middleware ()
   (unless (featurep 'cider)

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -1260,9 +1260,13 @@ word test in it and whether the file lives under the test/ directory."
                'cljr--maybe-eval-ns-form-and-remove-hook :local))
 
 (defun cljr--maybe-sort-ns ()
-  (when (and cljr-auto-sort-ns (cider-connected-p)
-             (cljr--op-supported-p "clean-ns"))
-    (cljr--clean-ns nil :no-pruning)))
+  (when cljr-auto-sort-ns
+    (if (and (cider-connected-p) (cljr--op-supported-p "clean-ns"))
+        (cljr--clean-ns nil :no-pruning)
+      ;; Offline: sort the ns form syntactically via clojure-mode, quietly,
+      ;; so this stays useful without a running REPL.
+      (let ((inhibit-message t))
+        (ignore-errors (clojure-sort-ns))))))
 
 (defun cljr--sort-and-remove-hook (&rest _)
   (cljr--maybe-sort-ns)
@@ -3036,11 +3040,20 @@ removed."
 (defun cljr-clean-ns ()
   "Clean the ns form for the current buffer.
 
+With the refactor-nrepl middleware available, unused libspecs are
+pruned and the ns form is sorted and reformatted.  Without a REPL, fall
+back to sorting the ns form with `clojure-sort-ns' - pruning needs
+analysis, so it is skipped.
+
 See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-clean-ns"
   (interactive)
-  (cljr--ensure-op-supported "clean-ns")
-  (cider-eval-ns-form)
-  (cljr--clean-ns))
+  (if (cljr--op-supported-p "clean-ns")
+      (progn
+        (cider-eval-ns-form)
+        (cljr--clean-ns))
+    (clojure-sort-ns)
+    (cljr--post-command-message
+     "Sorted the ns form (pruning unused libspecs needs the refactor-nrepl middleware).")))
 
 (defun cljr--uses-completion-framework-p ()
   "Whether the user is using something richer than the stock `completing-read'."

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -408,7 +408,23 @@ ex/"))))
         (cljr-slash))
       (expect (buffer-string) :to-equal "(ns foo
   (:require [clojure.string :as str]))
+str/")))
+  (it "falls back (rather than erroring) with no REPL connected"
+    ;; Regression: `cljr--op-supported-p' used to signal `No linked CIDER
+    ;; sessions' when disconnected, so typing `/' offline threw instead of
+    ;; falling back to the static table.
+    (spy-on 'cider-connected-p :and-return-value nil)
+    (cljr--with-clojure-temp-file "foo.clj"
+      (with-point-at "(ns foo)\nstr|"
+        (cljr-slash))
+      (expect (buffer-string) :to-equal "(ns foo
+  (:require [clojure.string :as str]))
 str/"))))
+
+(describe "cljr--op-supported-p"
+  (it "returns nil (rather than erroring) when no REPL is connected"
+    (spy-on 'cider-connected-p :and-return-value nil)
+    (expect (cljr--op-supported-p "clean-ns") :to-be nil)))
 
 (describe "cljr--remove-tramp-prefix-from-msg"
   (it "Removes the tramp prefix from specifc nrepl message attributes"

--- a/tests/unit-test.el
+++ b/tests/unit-test.el
@@ -426,6 +426,29 @@ str/"))))
     (spy-on 'cider-connected-p :and-return-value nil)
     (expect (cljr--op-supported-p "clean-ns") :to-be nil)))
 
+(describe "cljr-clean-ns offline fallback"
+  ;; Drive the real `cljr--op-supported-p' by faking a disconnected REPL,
+  ;; instead of stubbing the predicate the fallback hinges on.
+  (before-each (spy-on 'cider-connected-p :and-return-value nil))
+  (it "sorts the ns form when no REPL is connected"
+    (spy-on 'cljr--post-command-message)
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo\n  (:require [b.b :as b]\n            [a.a :as a]))\n")
+      (cljr-clean-ns)
+      (expect (buffer-string) :to-equal "(ns foo
+  (:require [a.a :as a]
+            [b.b :as b]))
+")))
+  (it "doesn't touch the middleware when no REPL is connected"
+    (spy-on 'cljr--clean-ns)
+    (spy-on 'cider-eval-ns-form)
+    (spy-on 'cljr--post-command-message)
+    (cljr--with-clojure-temp-file "foo.clj"
+      (insert "(ns foo\n  (:require [a.a :as a]))\n")
+      (cljr-clean-ns)
+      (expect 'cljr--clean-ns :not :to-have-been-called)
+      (expect 'cider-eval-ns-form :not :to-have-been-called))))
+
 (describe "cljr--remove-tramp-prefix-from-msg"
   (it "Removes the tramp prefix from specifc nrepl message attributes"
     (with-temp-buffer


### PR DESCRIPTION
Two related changes:

1. **Fix a real regression in the offline fallbacks.** `cljr--op-supported-p` delegates to `cider-nrepl-op-supported-p`, which resolves the REPL with the `ensure` flag and signals "No linked CIDER sessions" when nothing is connected. So the offline paths added recently never actually ran - typing `/` (`cljr-slash`) or calling `cljr-add-missing-libspec` without a REPL threw instead of falling back. Now the predicate guards on `cider-connected-p` and returns nil when disconnected.

2. **Make `cljr-clean-ns` work offline.** Pruning unused libspecs needs analysis, but sorting the ns form is purely syntactic, so without the middleware it now falls back to clojure-mode's `clojure-sort-ns` (and skips pruning) instead of erroring. The auto-sort hook does the same, so ns forms get tidied offline too.

Found the regression in (1) while adding (2) - the same unguarded predicate was the culprit.