### PR TITLE
Housekeeping ahead of the 4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ If you are an IDO user, you will get better completions by installing the [`ido-
 (add-hook 'clojure-mode-hook #'my-clojure-mode-hook)
 ```
 
+If you're using [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode)
+(fully supported by CIDER these days), hook that mode as well (or instead):
+
+```emacs-lisp
+(add-hook 'clojure-ts-mode-hook #'my-clojure-mode-hook)
+```
+
 The more advanced refactorings require our nREPL middleware
 [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl). From
 version *2.2.0* onwards if `cider-jack-in` is used it is injected

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,17 +49,24 @@ Apply the same module-by-module audit approach we've used in CIDER: behavior-
 preserving cleanups on focused branches, lean on built-ins, deprecate public
 names with `make-obsolete` rather than deleting them outright. Concretely:
 
-- Remove dead code and long-obsolete aliases (the 2.x-era threading/cycling
-  aliases that moved to clojure-mode years ago).
-- Drop defensive compat checks that the Emacs 28+ / hard-`cider`-dependency
-  baseline made unnecessary.
-- Make narrow, heavyweight dependencies (multiple-cursors, hydra, inflections)
-  soft/optional - each backs a single slice of functionality.
-- Fix the test story. The Cucumber/ecukes feature suite is no longer wired into
-  CI; the buttercup suite is the modern target and should grow to cover the
-  pure-structural commands (which need no REPL to test).
+- ~~Remove dead code and long-obsolete aliases (the 2.x-era threading/cycling
+  aliases that moved to clojure-mode years ago).~~ Done for 4.0.
+- ~~Drop defensive compat checks that the Emacs 28+ / hard-`cider`-dependency
+  baseline made unnecessary.~~ Done for 4.0.
+- ~~Make narrow, heavyweight dependencies (multiple-cursors, hydra, inflections)
+  soft/optional.~~ Done for 4.0 - they were dropped outright.
+- Grow the buttercup suite to cover the pure-structural commands (which need
+  no REPL to test). Both suites (buttercup and the ecukes feature suite) run
+  in CI these days; buttercup remains the target for new tests.
 - Split the single large source file along its existing logical seams, which
   also cleanly separates the AST-dependent commands from the rest.
+- Vet every command under `clojure-ts-mode`, now that CIDER treats it as a
+  first-class citizen. The commands delegate a lot to clojure-mode functions,
+  which mostly work in ts buffers but can fail silently where sexp movement
+  differs (the offline ns sort was one such case, fixed for 4.0).
+- Migrate the jack-in injection off the legacy `cider-jack-in-lein-plugins` /
+  `cider-add-to-alist` API when CIDER offers a modern replacement; the legacy
+  vars still work in CIDER 2.0 but won't live forever.
 
 ### Move high-impact, analysis-free features into CIDER
 
@@ -70,9 +77,8 @@ deprecate the clj-refactor copies. `cljr-slash`, `add-missing-libspec`, and
 `clean-ns` are the first targets - none of them need the AST index, so they can
 move without dragging the slow analyzer along.
 
-The idiosyncratic, dependency-heavy parts (yasnippet snippets, hydras,
-multiple-cursors integration) stay in clj-refactor.el. They don't belong in
-CIDER core.
+The idiosyncratic parts (e.g. the yasnippet-based ns/defn snippets) stay in
+clj-refactor.el. They don't belong in CIDER core.
 
 ### Make the analysis fast and robust
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -7,7 +7,7 @@
 ;;         Lars Andersen <expez@expez.com>
 ;;         Benedek Fazekas <benedek.fazekas@gmail.com>
 ;;         Bozhidar Batsov <bozhidar@batsov.dev>
-;; Version: 3.12.0
+;; Version: 4.0.0-snapshot
 ;; Keywords: convenience, clojure, cider
 
 ;; Package-Requires: ((emacs "28.1") (yasnippet "0.6.1") (paredit "24") (clojure-mode "5.18.0") (cider "1.11.1") (parseedn "1.2.0") (transient "0.4.1") (spinner "1.7"))
@@ -3925,7 +3925,7 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-inline-symbol"
             (cljr--post-command-message "No occurrences of '%s' found.  Deleted the definition." symbol)))))
     (cljr--indent-defun)))
 
-(defconst cljr-version "3.11.3"
+(defconst cljr-version "4.0.0-snapshot"
   "The current version of clj-refactor.")
 
 (defun cljr--pkg-version ()


### PR DESCRIPTION
Three small things spotted while auditing the repo against the CIDER 2.0 release:

- The version metadata disagreed with itself (`Version: 3.12.0` header, `cljr-version` \"3.11.3\") and with the README's 4.0.0+ compatibility table. Both are now `4.0.0-snapshot`, CIDER-style; the suffix gets dropped at the cut.
- The setup docs only mentioned `clojure-mode-hook`, so clojure-ts-mode users never got `clj-refactor-mode` enabled. Now documented.
- The roadmap still listed work that shipped (dep slimming, alias removal) and claimed the ecukes suite isn't in CI (it is). Marked those done and added two new items: the clojure-ts-mode vetting sweep and the eventual jack-in injection API migration.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)