### PR TITLE
Require CIDER 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 
+- **(Breaking)** Require CIDER 2.0+ (and drop the small compat shims for the pre-2.0 API names).
 - Use refactor-nrepl's namespaced op names (`refactor/find-symbol`, `refactor/clean-ns`, …) when the middleware advertises them (refactor-nrepl 3.13.0+, the injected version is now 3.14.0), falling back to the bare names on older versions. refactor-nrepl treats the namespaced forms as canonical and plans to drop the bare names, and namespacing avoids op-name collisions with other middleware.
 - Don't error out of `cider-connected-hook` when the refactor-nrepl middleware is missing: the connect-time version probe now degrades to the existing "out of sync" warning instead of aborting the startup checks with a cryptic error (visible with CIDER 2.0, whose senders reject unsupported ops client-side).
 - Fix the offline ns-form sort (`cljr-clean-ns` and `cljr-auto-sort-ns` without a REPL) silently doing nothing in `clojure-ts-mode` buffers, where the tree-sitter `forward-sexp-function` broke `clojure-sort-ns`.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ profile found at `~/.lein/profiles.clj`:
 
 ```clojure
 :plugins [[refactor-nrepl "3.14.0"]
-          [cider/cider-nrepl "0.61.0"]]
+          [cider/cider-nrepl "0.62.1"]]
 ```
 
 Check out the much longer
@@ -81,7 +81,7 @@ clj-refactor | refactor-nrepl | CIDER       | Clojure | Java |
 2.4.0        |  2.4.0         | 0.17, 0.18  | 1.7+    | 8+   |
 2.5.0        |  2.5.0         | 0.24        | 1.8+    | 8+   |
 3.0.0+       |  3.0.0+        | 1.0         | 1.9+    | 11+  |
-4.0.0+       |  3.x (3.13.0+ recommended) | 1.11+ | 1.10+ | 8+ |
+4.0.0+       |  3.x (3.13.0+ recommended) | 2.0+  | 1.10+ | 8+ |
 
 clj-refactor 4.0.0+ requires Emacs 28.1 or newer.
 

--- a/clj-refactor.el
+++ b/clj-refactor.el
@@ -10,7 +10,7 @@
 ;; Version: 4.0.0-snapshot
 ;; Keywords: convenience, clojure, cider
 
-;; Package-Requires: ((emacs "28.1") (yasnippet "0.6.1") (paredit "24") (clojure-mode "5.18.0") (cider "1.11.1") (parseedn "1.2.0") (transient "0.4.1") (spinner "1.7"))
+;; Package-Requires: ((emacs "28.1") (yasnippet "0.6.1") (paredit "24") (clojure-mode "5.18.0") (cider "2.0.0") (parseedn "1.2.0") (transient "0.4.1") (spinner "1.7"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -2627,26 +2627,12 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-sort-project-dep
         (indent-region (point-min) (point-max))
         (save-buffer)))))
 
-;; CIDER 1.23 renamed `cider-nrepl-send-sync-request' to
-;; `cider-nrepl-sync-request' and `cider-ensure-connected' to
-;; `cider-ensure-session'.  Prefer the modern names when they're available and
-;; fall back to the old ones, so we keep working with older CIDER releases.
-(defalias 'cljr--nrepl-sync-request
-  (if (fboundp 'cider-nrepl-sync-request)
-      'cider-nrepl-sync-request
-    'cider-nrepl-send-sync-request))
-
-(defalias 'cljr--ensure-session
-  (if (fboundp 'cider-ensure-session)
-      'cider-ensure-session
-    'cider-ensure-connected))
-
 (defun cljr--call-middleware-sync (request &optional key)
   "Call the middleware with REQUEST.
 
 If it's present KEY indicates the key to extract from the response."
   (let* ((nrepl-sync-request-timeout (if cljr-warn-on-eval nil 25))
-         (response (thread-first request cljr--nrepl-sync-request cljr--maybe-rethrow-error)))
+         (response (thread-first request cider-nrepl-sync-request cljr--maybe-rethrow-error)))
     (if key
         (nrepl-dict-get response key)
       response)))
@@ -4054,7 +4040,7 @@ warning by customizing `cljr-suppress-no-project-warning'.)"))))
 
 (defun cljr--ns-path (ns-name)
   "Find the file path to the ns named NS-NAME."
-  (cljr--ensure-session)
+  (cider-ensure-session)
   ;; No explicit op-support check: `cider-sync-request:ns-path' sends the
   ;; namespaced `cider/ns-path' op, whose support modern CIDER enforces in the
   ;; nREPL sender automatically.


### PR DESCRIPTION
With CIDER 2.0 released there's little reason for clj-refactor 4.0 to keep supporting year-old CIDER versions. This bumps the package requirement and deletes the two load-time defaliases that bridged the pre-2.0 API names. The README's compatibility table and manual-middleware snippet are updated to match (cider-nrepl 0.62.1 is what CIDER 2.0 pairs with).

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] The new code is not generating byte compile warnings (run `make compile`)
- [x] All tests are passing (run `make test`)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)